### PR TITLE
[NEWSD][1.45] Added support of NEWGROUPS and NEWNEWS commands

### DIFF
--- a/Server.C
+++ b/Server.C
@@ -556,22 +556,24 @@ int Server::CommandLoop(const char *overview[])
 		continue;
 	    }
 
-        // TODO Correct error occuring
+        // Parse date input
 	    int year, mon, day, hour, min, sec;
-	    if ( (sscanf(arg1, "%2d%2d%2d", &year, &mon, &day) != 3 ||
-	         sscanf(arg1, "%4d%2d%2d", &year, &mon, &day) != 3) ||
-	         sscanf(arg2, "%2d%2d%2d", &hour, &min, &sec) != 3 )
-	    {
-	        Send("501 Bad date/time argument");
-		continue;
-	    }
-
-	    // TBD
-	    //     1) TRANSLATE YY -> YYYY - NOT MANDATORY, CHECK `man 3 strptime`
-        //        FOR MORE INFORMATION ('%y' FORMAT PARAMETER)
-	    //     2) TRANSLATE TIMES INTO A time() VALUE
-	    //     3) COMPARE TIME TO GROUP'S CTIME
-	    //
+        if (strlen(arg1) == 6) {
+            if ( sscanf(arg1, "%2d%2d%2d", &year, &mon, &day) != 3 ||
+                 sscanf(arg2, "%2d%2d%2d", &hour, &min, &sec) != 3 )
+            {
+                Send("501 Bad date/time argument");
+            continue;
+            }
+        }
+        else {
+            if ( sscanf(arg1, "%4d%2d%2d", &year, &mon, &day) != 3 ||
+                 sscanf(arg2, "%2d%2d%2d", &hour, &min, &sec) != 3 )
+            {
+                Send("501 Bad date/time argument");
+            continue;
+            }
+        }
 
         // Get time input
         char *inputTime = (char *) malloc(14 * sizeof (char));

--- a/doc/rfc3977.txt
+++ b/doc/rfc3977.txt
@@ -1,0 +1,7003 @@
+
+
+
+
+
+
+Network Working Group                                         C. Feather
+Request for Comments: 3977                                      THUS plc
+Obsoletes: 977                                              October 2006
+Updates: 2980
+Category: Standards Track
+
+
+                 Network News Transfer Protocol (NNTP)
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   The Network News Transfer Protocol (NNTP) has been in use in the
+   Internet for a decade, and remains one of the most popular protocols
+   (by volume) in use today.  This document is a replacement for
+   RFC 977, and officially updates the protocol specification.  It
+   clarifies some vagueness in RFC 977, includes some new base
+   functionality, and provides a specific mechanism to add standardized
+   extensions to NNTP.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .  3
+     1.1.  Author's Note . . . . . . . . . . . . . . . . . . . . . .  4
+   2.  Notation  . . . . . . . . . . . . . . . . . . . . . . . . . .  5
+   3.  Basic Concepts  . . . . . . . . . . . . . . . . . . . . . . .  6
+     3.1.  Commands and Responses  . . . . . . . . . . . . . . . . .  6
+       3.1.1.  Multi-line Data Blocks . . . . . . . . . . . . . . . . 8
+     3.2.  Response Codes  . . . . . . . . . . . . . . . . . . . . .  9
+       3.2.1.  Generic Response Codes  . . . . . . . . . . . . . . . 10
+         3.2.1.1.  Examples  . . . . . . . . . . . . . . . . . . . . 12
+     3.3.  Capabilities and Extensions . . . . . . . . . . . . . . . 14
+       3.3.1.  Capability Descriptions . . . . . . . . . . . . . . . 14
+       3.3.2.  Standard Capabilities . . . . . . . . . . . . . . . . 15
+       3.3.3.  Extensions  . . . . . . . . . . . . . . . . . . . . . 16
+       3.3.4.  Initial IANA Register . . . . . . . . . . . . . . . . 18
+     3.4.  Mandatory and Optional Commands . . . . . . . . . . . . . 20
+
+
+
+Feather                     Standards Track                     [Page 1]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+       3.4.1.  Reading and Transit Servers . . . . . . . . . . . . . 21
+       3.4.2.  Mode Switching  . . . . . . . . . . . . . . . . . . . 21
+     3.5.  Pipelining  . . . . . . . . . . . . . . . . . . . . . . . 22
+       3.5.1.  Examples  . . . . . . . . . . . . . . . . . . . . . . 23
+     3.6.  Articles  . . . . . . . . . . . . . . . . . . . . . . . . 24
+   4.  The WILDMAT Format  . . . . . . . . . . . . . . . . . . . . . 25
+     4.1.  Wildmat Syntax  . . . . . . . . . . . . . . . . . . . . . 26
+     4.2.  Wildmat Semantics . . . . . . . . . . . . . . . . . . . . 26
+     4.3.  Extensions  . . . . . . . . . . . . . . . . . . . . . . . 27
+     4.4.  Examples  . . . . . . . . . . . . . . . . . . . . . . . . 27
+   5.  Session Administration Commands . . . . . . . . . . . . . . . 28
+     5.1.  Initial Connection  . . . . . . . . . . . . . . . . . . . 28
+     5.2.  CAPABILITIES  . . . . . . . . . . . . . . . . . . . . . . 29
+     5.3.  MODE READER . . . . . . . . . . . . . . . . . . . . . . . 32
+     5.4.  QUIT  . . . . . . . . . . . . . . . . . . . . . . . . . . 34
+   6.  Article Posting and Retrieval . . . . . . . . . . . . . . . . 35
+     6.1.  Group and Article Selection . . . . . . . . . . . . . . . 36
+       6.1.1.  GROUP . . . . . . . . . . . . . . . . . . . . . . . . 36
+       6.1.2.  LISTGROUP . . . . . . . . . . . . . . . . . . . . . . 39
+       6.1.3.  LAST  . . . . . . . . . . . . . . . . . . . . . . . . 42
+       6.1.4.  NEXT  . . . . . . . . . . . . . . . . . . . . . . . . 44
+     6.2.  Retrieval of Articles and Article Sections  . . . . . . . 45
+       6.2.1.  ARTICLE . . . . . . . . . . . . . . . . . . . . . . . 46
+       6.2.2.  HEAD  . . . . . . . . . . . . . . . . . . . . . . . . 49
+       6.2.3.  BODY  . . . . . . . . . . . . . . . . . . . . . . . . 51
+       6.2.4.  STAT  . . . . . . . . . . . . . . . . . . . . . . . . 53
+     6.3.  Article Posting . . . . . . . . . . . . . . . . . . . . . 56
+       6.3.1.  POST  . . . . . . . . . . . . . . . . . . . . . . . . 56
+       6.3.2.  IHAVE . . . . . . . . . . . . . . . . . . . . . . . . 58
+   7.  Information Commands  . . . . . . . . . . . . . . . . . . . . 61
+     7.1.  DATE  . . . . . . . . . . . . . . . . . . . . . . . . . . 61
+     7.2.  HELP  . . . . . . . . . . . . . . . . . . . . . . . . . . 62
+     7.3.  NEWGROUPS . . . . . . . . . . . . . . . . . . . . . . . . 63
+     7.4.  NEWNEWS . . . . . . . . . . . . . . . . . . . . . . . . . 64
+     7.5.  Time  . . . . . . . . . . . . . . . . . . . . . . . . . . 65
+       7.5.1.  Examples  . . . . . . . . . . . . . . . . . . . . . . 66
+     7.6.  The LIST Commands . . . . . . . . . . . . . . . . . . . . 66
+       7.6.1.  LIST  . . . . . . . . . . . . . . . . . . . . . . . . 67
+       7.6.2.  Standard LIST Keywords  . . . . . . . . . . . . . . . 69
+       7.6.3.  LIST ACTIVE . . . . . . . . . . . . . . . . . . . . . 70
+       7.6.4.  LIST ACTIVE.TIMES . . . . . . . . . . . . . . . . . . 71
+       7.6.5.  LIST DISTRIB.PATS . . . . . . . . . . . . . . . . . . 72
+       7.6.6.  LIST NEWSGROUPS . . . . . . . . . . . . . . . . . . . 73
+   8.  Article Field Access Commands . . . . . . . . . . . . . . . . 73
+     8.1.  Article Metadata  . . . . . . . . . . . . . . . . . . . . 74
+       8.1.1.  The :bytes Metadata Item  . . . . . . . . . . . . . . 74
+       8.1.2.  The :lines Metadata Item  . . . . . . . . . . . . . . 75
+     8.2.  Database Consistency  . . . . . . . . . . . . . . . . . . 75
+
+
+
+Feather                     Standards Track                     [Page 2]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+     8.3.  OVER  . . . . . . . . . . . . . . . . . . . . . . . . . . 76
+     8.4.  LIST OVERVIEW.FMT . . . . . . . . . . . . . . . . . . . . 81
+     8.5.  HDR . . . . . . . . . . . . . . . . . . . . . . . . . . . 83
+     8.6.  LIST HEADERS  . . . . . . . . . . . . . . . . . . . . . . 87
+   9.  Augmented BNF Syntax for NNTP . . . . . . . . . . . . . . . . 90
+     9.1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . 90
+     9.2.  Commands  . . . . . . . . . . . . . . . . . . . . . . . . 92
+     9.3.  Command Continuation  . . . . . . . . . . . . . . . . . . 93
+     9.4.  Responses . . . . . . . . . . . . . . . . . . . . . . . . 93
+       9.4.1.  Generic Responses . . . . . . . . . . . . . . . . . . 93
+       9.4.2.  Initial Response Line Contents  . . . . . . . . . . . 94
+       9.4.3.  Multi-line Response Contents  . . . . . . . . . . . . 94
+     9.5.  Capability Lines  . . . . . . . . . . . . . . . . . . . . 95
+     9.6.  LIST Variants . . . . . . . . . . . . . . . . . . . . . . 96
+     9.7.  Articles  . . . . . . . . . . . . . . . . . . . . . . . . 97
+     9.8.  General Non-terminals . . . . . . . . . . . . . . . . . . 97
+     9.9.  Extensions and Validation . . . . . . . . . . . . . . . . 99
+   10. Internationalisation Considerations . . . . . . . . . . . . .100
+     10.1. Introduction and Historical Situation . . . . . . . . . .100
+     10.2. This Specification  . . . . . . . . . . . . . . . . . . .101
+     10.3. Outstanding Issues  . . . . . . . . . . . . . . . . . . .102
+   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .103
+   12. Security Considerations . . . . . . . . . . . . . . . . . . .103
+     12.1. Personal and Proprietary Information  . . . . . . . . . .104
+     12.2. Abuse of Server Log Information . . . . . . . . . . . . .104
+     12.3. Weak Authentication and Access Control  . . . . . . . . .104
+     12.4. DNS Spoofing  . . . . . . . . . . . . . . . . . . . . . .104
+     12.5. UTF-8 Issues  . . . . . . . . . . . . . . . . . . . . . .105
+     12.6. Caching of Capability Lists . . . . . . . . . . . . . . .106
+   13. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .107
+   14. References  . . . . . . . . . . . . . . . . . . . . . . . . .110
+     14.1. Normative References  . . . . . . . . . . . . . . . . . .110
+     14.2. Informative References  . . . . . . . . . . . . . . . . .110
+   A.  Interaction with Other Specifications . . . . . . . . . . . .112
+     A.1.  Header Folding  . . . . . . . . . . . . . . . . . . . . .112
+     A.2.  Message-IDs . . . . . . . . . . . . . . . . . . . . . . .112
+     A.3.  Article Posting . . . . . . . . . . . . . . . . . . . . .114
+   B.  Summary of Commands . . . . . . . . . . . . . . . . . . . . .115
+   C.  Summary of Response Codes . . . . . . . . . . . . . . . . . .117
+   D.  Changes from RFC 977  . . . . . . . . . . . . . . . . . . . .121
+
+1.  Introduction
+
+   This document specifies the Network News Transfer Protocol (NNTP),
+   which is used for the distribution, inquiry, retrieval, and posting
+   of Netnews articles using a reliable stream-based mechanism.  For
+   news-reading clients, NNTP enables retrieval of news articles that
+
+
+
+
+Feather                     Standards Track                     [Page 3]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   are stored in a central database, giving subscribers the ability to
+   select only those articles they wish to read.
+
+   The Netnews model provides for indexing, cross-referencing, and
+   expiration of aged messages.  NNTP is designed for efficient
+   transmission of Netnews articles over a reliable full duplex
+   communication channel.
+
+   Although the protocol specification in this document is largely
+   compatible with the version specified in RFC 977 [RFC977], a number
+   of changes are summarised in Appendix D.  In particular:
+
+   o  the default character set is changed from US-ASCII [ANSI1986] to
+      UTF-8 [RFC3629] (note that US-ASCII is a subset of UTF-8);
+
+   o  a number of commands that were optional in RFC 977 or that have
+      been taken from RFC 2980 [RFC2980] are now mandatory; and
+
+   o  a CAPABILITIES command has been added to allow clients to
+      determine what functionality is available from a server.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+   An implementation is not compliant if it fails to satisfy one or more
+   of the MUST requirements for this protocol.  An implementation that
+   satisfies all the MUST and all the SHOULD requirements for its
+   protocols is said to be "unconditionally compliant"; one that
+   satisfies all the MUST requirements but not all the SHOULD
+   requirements for NNTP is said to be "conditionally compliant".
+
+   For the remainder of this document, the terms "client" and "client
+   host" refer to a host making use of the NNTP service, while the terms
+   "server" and "server host" refer to a host that offers the NNTP
+   service.
+
+1.1.  Author's Note
+
+   This document is written in XML using an NNTP-specific DTD.  Custom
+   software is used to convert this to RFC 2629 [RFC2629] format, and
+   then the public "xml2rfc" package to further reduce this to text,
+   nroff source, and HTML.
+
+   No perl was used in producing this document.
+
+
+
+
+
+
+Feather                     Standards Track                     [Page 4]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+2.  Notation
+
+   The following notational conventions are used in this document.
+
+     UPPERCASE     indicates literal text to be included in the
+                   command.
+
+     lowercase     indicates a token described elsewhere.
+
+     [brackets]    indicate that the enclosed material is optional.
+
+     elliptical    indicates that the argument may be repeated any
+     ... marks     number of times (it must occur at least once).
+
+     vertical|bar  indicates a choice of two mutually exclusive
+                   arguments (exactly one must be provided).
+
+   The name "message-id" for a command or response argument indicates
+   that it is the message-id of an article as described in Section 3.6,
+   including the angle brackets.
+
+   The name "wildmat" for an argument indicates that it is a wildmat as
+   defined in Section 4.  If the argument does not meet the requirements
+   of that section (for example, if it does not fit the grammar of
+   Section 4.1), the NNTP server MAY place some interpretation on it
+   (not specified by this document) or otherwise MUST treat it as a
+   syntax error.
+
+   Responses for each command will be described in tables listing the
+   required format of a response followed by the meaning that should be
+   ascribed to that response.
+
+   The terms "NUL", "TAB", "LF", "CR, and "space" refer to the octets
+   %x00, %x09, %x0A, %x0D, and %x20, respectively (that is, the octets
+   with those codes in US-ASCII [ANSI1986] and thus in UTF-8 [RFC3629]).
+   The term "CRLF" or "CRLF pair" means the sequence CR immediately
+   followed by LF (that is, %x0D.0A).  A "printable US-ASCII character"
+   is an octet in the range %x21-7E.  Quoted characters refer to the
+   octets with those codes in US-ASCII (so "." and "<" refer to %x2E and
+   %x3C) and will always be printable US-ASCII characters; similarly,
+   "digit" refers to the octets %x30-39.
+
+   A "keyword" MUST consist only of US-ASCII letters, digits, and the
+   characters dot (".") and dash ("-") and MUST begin with a letter.
+   Keywords MUST be at least three characters in length.
+
+
+
+
+
+
+Feather                     Standards Track                     [Page 5]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Examples in this document are not normative but serve to illustrate
+   usages, arguments, and responses.  In the examples, a "[C]" will be
+   used to represent the client host and an "[S]" will be used to
+   represent the server host.  Most of the examples do not rely on a
+   particular server state.  In some cases, however, they do assume that
+   the currently selected newsgroup (see the GROUP command,
+   Section 6.1.1) is invalid; when so, this is indicated at the start of
+   the example.  Examples may use commands or other keywords not defined
+   in this specification (such as an XENCRYPT command).  These will be
+   used to illustrate some point and do not imply that any such command
+   is defined elsewhere or needs to exist in any particular
+   implementation.
+
+   Terms that might be read as specifying details of a client or server
+   implementation, such as "database", are used simply to ease
+   description.  Provided that implementations conform to the protocol
+   and format specifications in this document, no specific technique is
+   mandated.
+
+3.  Basic Concepts
+
+3.1.  Commands and Responses
+
+   NNTP operates over any reliable bi-directional 8-bit-wide data stream
+   channel.  When the connection is established, the NNTP server host
+   MUST send a greeting.  The client host and server host then exchange
+   commands and responses (respectively) until the connection is closed
+   or aborted.  If the connection used is TCP, then the server host
+   starts the NNTP service by listening on a TCP port.  When a client
+   host wishes to make use of the service, it MUST establish a TCP
+   connection with the server host by connecting to that host on the
+   same port on which the server is listening.
+
+   The character set for all NNTP commands is UTF-8 [RFC3629].  Commands
+   in NNTP MUST consist of a keyword, which MAY be followed by one or
+   more arguments.  A CRLF pair MUST terminate all commands.  Multiple
+   commands MUST NOT be on the same line.  Unless otherwise noted
+   elsewhere in this document, arguments SHOULD consist of printable US-
+   ASCII characters.  Keywords and arguments MUST each be separated by
+   one or more space or TAB characters.  Command lines MUST NOT exceed
+   512 octets, which includes the terminating CRLF pair.  The arguments
+   MUST NOT exceed 497 octets.  A server MAY relax these limits for
+   commands defined in an extension.
+
+   Where this specification permits UTF-8 characters outside the range
+   of U+0000 to U+007F, implementations MUST NOT use the Byte Order Mark
+   (U+FEFF, encoding %xEF.BB.BF) and MUST use the Word Joiner (U+2060,
+   encoding %xE2.91.A0) for the meaning Zero Width No-Break Space in
+
+
+
+Feather                     Standards Track                     [Page 6]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   command lines and the initial lines of responses.  Implementations
+   SHOULD apply these same principles throughout.
+
+   The term "character" means a single Unicode code point.
+   Implementations are not required to carry out Unicode normalisation.
+   Thus, U+0084 (A-dieresis) is one character, while U+0041 U+0308 (A
+   composed with dieresis) is two; the two need not be treated as
+   equivalent.
+
+   Commands may have variants; if so, they use a second keyword
+   immediately after the first to indicate which variant is required.
+   The only such commands in this specification are LIST and MODE.  Note
+   that such variants are sometimes referred to as if they were commands
+   in their own right: "the LIST ACTIVE" command should be read as
+   shorthand for "the ACTIVE variant of the LIST command".
+
+   Keywords are case insensitive; the case of keywords for commands MUST
+   be ignored by the server.  Command and response arguments are case or
+   language specific only when stated, either in this document or in
+   other relevant specifications.
+
+   In some cases, a command involves more data than just a single line.
+   The further data may be sent either immediately after the command
+   line (there are no instances of this in this specification, but there
+   are in extensions such as [NNTP-STREAM]) or following a request from
+   the server (indicated by a 3xx response).
+
+   Each response MUST start with a three-digit response code that is
+   sufficient to distinguish all responses.  Certain valid responses are
+   defined to be multi-line; for all others, the response is contained
+   in a single line.  The initial line of the response MUST NOT exceed
+   512 octets, which includes the response code and the terminating CRLF
+   pair; an extension MAY specify a greater maximum for commands that it
+   defines, but not for any other command.  Single-line responses
+   consist of an initial line only.  Multi-line responses consist of an
+   initial line followed by a multi-line data block.
+
+   An NNTP server MAY have an inactivity autologout timer.  Such a timer
+   SHOULD be of at least three minutes' duration, with the exception
+   that there MAY be a shorter limit on how long the server is willing
+   to wait for the first command from the client.  The receipt of any
+   command from the client during the timer interval SHOULD suffice to
+   reset the autologout timer.  Similarly, the receipt of any
+   significant amount of data from a client that is sending a multi-line
+   data block (such as during a POST or IHAVE command) SHOULD suffice to
+   reset the autologout timer.  When the timer expires, the server
+   SHOULD close the connection without sending any response to the
+   client.
+
+
+
+Feather                     Standards Track                     [Page 7]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+3.1.1.  Multi-line Data Blocks
+
+   A multi-line data block is used in certain commands and responses.
+   It MUST adhere to the following rules:
+
+   1.  The block consists of a sequence of zero or more "lines", each
+       being a stream of octets ending with a CRLF pair.  Apart from
+       those line endings, the stream MUST NOT include the octets NUL,
+       LF, or CR.
+
+   2.  In a multi-line response, the block immediately follows the CRLF
+       at the end of the initial line of the response.  When used in any
+       other context, the specific command will define when the block is
+       sent.
+
+   3.  If any line of the data block begins with the "termination octet"
+       ("." or %x2E), that line MUST be "dot-stuffed" by prepending an
+       additional termination octet to that line of the block.
+
+   4.  The lines of the block MUST be followed by a terminating line
+       consisting of a single termination octet followed by a CRLF pair
+       in the normal way.  Thus, unless it is empty, a multi-line block
+       is always terminated with the five octets CRLF "." CRLF
+       (%x0D.0A.2E.0D.0A).
+
+   5.  When a multi-line block is interpreted, the "dot-stuffing" MUST
+       be undone; i.e., the recipient MUST ensure that, in any line
+       beginning with the termination octet followed by octets other
+       than a CRLF pair, that initial termination octet is disregarded.
+
+   6.  Likewise, the terminating line ("." CRLF or %x2E.0D.0A) MUST NOT
+       be considered part of the multi-line block; i.e., the recipient
+       MUST ensure that any line beginning with the termination octet
+       followed immediately by a CRLF pair is disregarded.  (The first
+       CRLF pair of the terminating CRLF "." CRLF of a non-empty block
+       is, of course, part of the last line of the block.)
+
+   Note that texts using an encoding (such as UTF-16 or UTF-32) that may
+   contain the octets NUL, LF, or CR other than a CRLF pair cannot be
+   reliably conveyed in the above format (that is, they violate the MUST
+   requirement above).  However, except when stated otherwise, this
+   specification does not require the content to be UTF-8, and therefore
+   (subject to that same requirement) it MAY include octets above and
+   below 128 mixed arbitrarily.
+
+   This document does not place any limit on the length of a line in a
+   multi-line block.  However, the standards that define the format of
+   articles may do so.
+
+
+
+Feather                     Standards Track                     [Page 8]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+3.2.  Response Codes
+
+   Each response MUST begin with a three-digit status indicator.  These
+   are status reports from the server and indicate the response to the
+   last command received from the client.
+
+   The first digit of the response broadly indicates the success,
+   failure, or progress of the previous command:
+
+      1xx - Informative message
+      2xx - Command completed OK
+      3xx - Command OK so far; send the rest of it
+      4xx - Command was syntactically correct but failed for some reason
+      5xx - Command unknown, unsupported, unavailable, or syntax error
+
+   The next digit in the code indicates the function response category:
+
+      x0x - Connection, setup, and miscellaneous messages
+      x1x - Newsgroup selection
+      x2x - Article selection
+      x3x - Distribution functions
+      x4x - Posting
+      x8x - Reserved for authentication and privacy extensions
+      x9x - Reserved for private use (non-standard extensions)
+
+   Certain responses contain arguments such as numbers and names in
+   addition to the status indicator.  In those cases, to simplify
+   interpretation by the client, the number and type of such arguments
+   is fixed for each response code, as is whether the code is
+   single-line or multi-line.  Any extension MUST follow this principle
+   as well.  Note that, for historical reasons, the 211 response code is
+   an exception to this in that the response may be single-line or
+   multi-line depending on the command (GROUP or LISTGROUP) that
+   generated it.  In all other cases, the client MUST only use the
+   status indicator itself to determine the nature of the response.  The
+   exact response codes that can be returned by any given command are
+   detailed in the description of that command.
+
+   Arguments MUST be separated from the numeric status indicator and
+   from each other by a single space.  All numeric arguments MUST be in
+   base 10 (decimal) format and MAY have leading zeros.  String
+   arguments MUST contain at least one character and MUST NOT contain
+   TAB, LF, CR, or space.  The server MAY add any text after the
+   response code or last argument, as appropriate, and the client MUST
+   NOT make decisions based on this text.  Such text MUST be separated
+   from the numeric status indicator or the last argument by at least
+   one space.
+
+
+
+
+Feather                     Standards Track                     [Page 9]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   The server MUST respond to any command with the appropriate generic
+   response (given in Section 3.2.1) if it represents the situation.
+   Otherwise, each recognized command MUST return one of the response
+   codes specifically listed in its description or in an extension.  A
+   server MAY provide extensions to this specification, including new
+   commands, new variants or features of existing commands, and other
+   ways of changing the internal state of the server.  However, the
+   server MUST NOT produce any other responses to a client that does not
+   invoke any of the additional features.  (Therefore, a client that
+   restricts itself to this specification will only receive the
+   responses that are listed.)
+
+   If a client receives an unexpected response, it SHOULD use the first
+   digit of the response to determine the result.  For example, an
+   unexpected 2xx should be taken as success, and an unexpected 4xx or
+   5xx as failure.
+
+   Response codes not specified in this document MAY be used for any
+   installation-specific additional commands also not specified.  These
+   SHOULD be chosen to fit the pattern of x9x specified above.
+
+   Neither this document nor any registered extension (see
+   Section 3.3.3) will specify any response codes of the x9x pattern.
+   (Implementers of extensions are accordingly cautioned not to use such
+   responses for extensions that may subsequently be submitted for
+   registration.)
+
+3.2.1.  Generic Response Codes
+
+   The server MUST respond to any command with the appropriate one of
+   the following generic responses if it represents the situation.
+
+   If the command is not recognized, or if it is an optional command
+   that is not implemented by the server, the response code 500 MUST be
+   returned.
+
+   If there is a syntax error in the arguments of a recognized command,
+   including the case where more arguments are provided than the command
+   specifies or the command line is longer than the server accepts, the
+   response code 501 MUST be returned.  The line MUST NOT be truncated
+   or split and then interpreted.  Note that where a command has
+   variants depending on a second keyword (e.g., LIST ACTIVE and LIST
+   NEWSGROUPS), 501 MUST be used when the base command is implemented
+   but the requested variant is not, and 500 MUST be used only when the
+   base command itself is not implemented.
+
+   If an argument is required to be a base64-encoded string [RFC4648]
+   (there are no such arguments in this specification, but there may be
+
+
+
+Feather                     Standards Track                    [Page 10]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   in extensions) and is not validly encoded, the response code 504 MUST
+   be returned.
+
+   If the server experiences an internal fault or problem that means it
+   is unable to carry out the command (for example, a necessary file is
+   missing or a necessary service could not be contacted), the response
+   code 403 MUST be returned.  If the server recognizes the command but
+   does not provide an optional feature (for example, because it does
+   not store the required information), or if it only handles a subset
+   of legitimate cases (see the HDR command, Section 8.5, for an
+   example), the response code 503 MUST be returned.
+
+   If the client is not authorized to use the specified facility when
+   the server is in its current state, then the appropriate one of the
+   following response codes MUST be used.
+
+   502: It is necessary to terminate the connection and to start a new
+      one with the appropriate authority before the command can be used.
+      Historically, some mode-switching servers (see Section 3.4.1) used
+      this response to indicate that this command will become available
+      after the MODE READER command (Section 5.3) is used, but this
+      usage does not conform to this specification and MUST NOT be used.
+      Note that the server MUST NOT close the connection immediately
+      after a 502 response except at the initial connection
+      (Section 5.1) and with the MODE READER command.
+
+   480: The client must authenticate itself to the server (that is, it
+      must provide information as to the identity of the client) before
+      the facility can be used on this connection.  This will involve
+      the use of an authentication extension such as [NNTP-AUTH].
+
+   483: The client must negotiate appropriate privacy protection on the
+      connection.  This will involve the use of a privacy extension such
+      as [NNTP-TLS].
+
+   401: The client must change the state of the connection in some other
+      manner.  The first argument of the response MUST be the capability
+      label (see Section 5.2) of the facility that provides the
+      necessary mechanism (usually an extension, which may be a private
+      extension).  The server MUST NOT use this response code except as
+      specified by the definition of the capability in question.
+
+   If the server has to terminate the connection for some reason, it
+   MUST give a 400 response code to the next command and then
+   immediately close the connection.  Following a 400 response, clients
+   SHOULD NOT simply reconnect immediately and retry the same actions.
+   Rather, a client SHOULD either use an exponentially increasing delay
+   between retries (e.g., double the waiting time after each 400
+
+
+
+Feather                     Standards Track                    [Page 11]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   response) or present any associated text to the user for them to
+   decide whether and when to retry.
+
+   The client MUST be prepared to receive any of these responses for any
+   command (except, of course, that the server MUST NOT generate a 500
+   response code for mandatory commands).
+
+3.2.1.1.  Examples
+
+   Example of an unknown command:
+
+      [C] MAIL
+      [S] 500 Unknown command
+
+   Example of an unsupported command:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] NEWNEWS
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+      [C] OVER
+      [S] 500 Unknown command
+
+   Example of an unsupported variant:
+
+      [C] MODE POSTER
+      [S] 501 Unknown MODE option
+
+   Example of a syntax error:
+
+      [C] ARTICLE a.message.id@no.angle.brackets
+      [S] 501 Syntax error
+
+   Example of an overlong command line:
+
+      [C] HEAD 53 54 55
+      [S] 501 Too many arguments
+
+   Example of a bad wildmat:
+
+      [C] LIST ACTIVE u[ks].*
+      [S] 501 Syntax error
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 12]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of a base64-encoding error (the second argument is meant to
+   be base64 encoded):
+
+      [C] XENCRYPT RSA abcd=efg
+      [S] 504 Base64 encoding error
+
+   Example of an attempt to access a facility not available to this
+   connection:
+
+      [C] MODE READER
+      [S] 200 Reader mode, posting permitted
+      [C] IHAVE <i.am.an.article.you.will.want@example.com>
+      [S] 500 Permission denied
+
+   Example of an attempt to access a facility requiring authentication:
+
+      [C] GROUP secret.group
+      [S] 480 Permission denied
+
+   Example of a successful attempt following such authentication:
+
+      [C] XSECRET fred flintstone
+      [S] 290 Password for fred accepted
+      [C] GROUP secret.group
+      [S] 211 5 1 20 secret.group selected
+
+   Example of an attempt to access a facility requiring privacy:
+
+      [C] GROUP secret.group
+      [S] 483 Secure connection required
+      [C] XENCRYPT
+      [Client and server negotiate encryption on the link]
+      [S] 283 Encrypted link established
+      [C] GROUP secret.group
+      [S] 211 5 1 20 secret.group selected
+
+   Example of a need to change mode before a facility is used:
+
+      [C] GROUP binary.group
+      [S] 401 XHOST Not on this virtual host
+      [C] XHOST binary.news.example.org
+      [S] 290 binary.news.example.org virtual host selected
+      [C] GROUP binary.group
+      [S] 211 5 1 77 binary.group selected
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 13]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of a temporary failure:
+
+      [C] GROUP archive.local
+      [S] 403 Archive server temporarily offline
+
+   Example of the server needing to close down immediately:
+
+      [C] ARTICLE 123
+      [S] 400 Power supply failed, running on UPS
+      [Server closes connection.]
+
+3.3.  Capabilities and Extensions
+
+   Not all NNTP servers provide exactly the same facilities, both
+   because this specification allows variation and because servers may
+   provide extensions.  A set of facilities that are related are called
+   a "capability".  This specification provides a way to determine what
+   capabilities are available, includes a list of standard capabilities,
+   and includes a mechanism (the extension mechanism) for defining new
+   capabilities.
+
+3.3.1.  Capability Descriptions
+
+   A client can determine the available capabilities of the server by
+   using the CAPABILITIES command (Section 5.2).  This returns a
+   capability list, which is a list of capability lines.  Each line
+   describes one available capability.
+
+   Each capability line consists of one or more tokens, which MUST be
+   separated by one or more space or TAB characters.  A token is a
+   string of 1 or more printable UTF-8 characters (that is, either
+   printable US-ASCII characters or any UTF-8 sequence outside the US-
+   ASCII range, but not space or TAB).  Unless stated otherwise, tokens
+   are case insensitive.  Each capability line consists of the
+   following:
+
+   o  The capability label, which is a keyword indicating the
+      capability.  A capability label may be defined by this
+      specification or a successor, or by an extension.
+
+   o  The label is then followed by zero or more tokens, which are
+      arguments of the capability.  The form and meaning of these tokens
+      is specific to each capability.
+
+   The server MUST ensure that the capability list accurately reflects
+   the capabilities (including extensions) currently available.  If a
+   capability is only available with the server in a certain state (for
+   example, only after authentication), the list MUST only include the
+
+
+
+Feather                     Standards Track                    [Page 14]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   capability label when the server is in that state.  Similarly, if
+   only some of the commands in an extension will be available, or if
+   the behaviour of the extension will change in some other manner,
+   according to the state of the server, this MUST be indicated by
+   different arguments in the capability line.
+
+   Note that a capability line can only begin with a letter.  Lines
+   beginning with other characters are reserved for future versions of
+   this specification.  In order to interoperate with such versions,
+   clients MUST be prepared to receive lines beginning with other
+   characters and MUST ignore any they do not understand.
+
+3.3.2.  Standard Capabilities
+
+   The following capabilities are defined by this specification.
+
+   VERSION
+      This capability MUST be advertised by all servers and MUST be the
+      first capability in the capability list; it indicates the
+      version(s) of NNTP that the server supports.  There must be at
+      least one argument; each argument is a decimal number and MUST NOT
+      have a leading zero.  Version numbers are assigned only in RFCs
+      that update or replace this specification; servers MUST NOT create
+      their own version numbers.
+
+      The version number of this specification is 2.
+
+   READER
+      This capability indicates that the server implements the various
+      commands useful for reading clients.
+
+   IHAVE
+      This capability indicates that the server implements the IHAVE
+      command.
+
+   POST
+      This capability indicates that the server implements the POST
+      command.
+
+   NEWNEWS
+      This capability indicates that the server implements the NEWNEWS
+      command.
+
+   HDR
+      This capability indicates that the server implements the header
+      access commands (HDR and LIST HEADERS).
+
+
+
+
+
+Feather                     Standards Track                    [Page 15]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   OVER
+      This capability indicates that the server implements the overview
+      access commands (OVER and LIST OVERVIEW.FMT).  If and only if the
+      server supports the message-id form of the OVER command, there
+      must be a single argument MSGID.
+
+   LIST
+      This capability indicates that the server implements at least one
+      variant of the LIST command.  There MUST be one argument for each
+      variant of the LIST command supported by the server, giving the
+      keyword for that variant.
+
+   IMPLEMENTATION
+      This capability MAY be provided by a server.  If so, the arguments
+      SHOULD be used to provide information such as the server software
+      name and version number.  The client MUST NOT use this line to
+      determine capabilities of the server.  (While servers often
+      provide this information in the initial greeting, clients need to
+      guess whether this is the case; this capability makes it clear
+      what the information is.)
+
+   MODE-READER
+      This capability indicates that the server is mode-switching
+      (Section 3.4.2) and that the MODE READER command needs to be used
+      to enable the READER capability.
+
+3.3.3.  Extensions
+
+   Although NNTP is widely and robustly deployed, some parts of the
+   Internet community might wish to extend the NNTP service.  It must be
+   emphasized that any extension to NNTP should not be considered
+   lightly.  NNTP's strength comes primarily from its simplicity.
+   Experience with many protocols has shown that:
+
+      Protocols with few options tend towards ubiquity, whilst protocols
+      with many options tend towards obscurity.
+
+   This means that each and every extension, regardless of its benefits,
+   must be carefully scrutinized with respect to its implementation,
+   deployment, and interoperability costs.  In many cases, the cost of
+   extending the NNTP service will likely outweigh the benefit.
+
+   An extension is a package of associated facilities, often but not
+   always including one or more new commands.  Each extension MUST
+   define at least one new capability label (this will often, but need
+   not, be the name of one of these new commands).  While any additional
+   capability information can normally be specified using arguments to
+
+
+
+
+Feather                     Standards Track                    [Page 16]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   that label, an extension MAY define more than one capability label.
+   However, this SHOULD be limited to exceptional circumstances.
+
+   An extension is either a private extension, or its capabilities are
+   included in the IANA registry of capabilities (see Section 3.3.4) and
+   it is defined in an RFC (in which case it is a "registered
+   extension").  Such RFCs either must be on the standards track or must
+   define an IESG-approved experimental protocol.
+
+   The definition of an extension must include the following:
+
+   o  a descriptive name for the extension.
+
+   o  the capability label or labels defined by the extension (the
+      capability label of a registered extension MUST NOT begin with
+      "X").
+
+   o  The syntax, values, and meanings of any arguments for each
+      capability label defined by the extension.
+
+   o  Any new NNTP commands associated with the extension (the names of
+      commands associated with registered extensions MUST NOT begin with
+      "X").
+
+   o  The syntax and possible values of arguments associated with the
+      new NNTP commands.
+
+   o  The response codes and possible values of arguments for the
+      responses of the new NNTP commands.
+
+   o  Any new arguments the extension associates with any other
+      pre-existing NNTP commands.
+
+   o  Any increase in the maximum length of commands and initial
+      response lines over the value specified in this document.
+
+   o  A specific statement about the effect on pipelining that this
+      extension may have (if any).
+
+   o  A specific statement about the circumstances when use of this
+      extension can alter the contents of the capabilities list (other
+      than the new capability labels it defines).
+
+   o  A specific statement about the circumstances under which the
+      extension can cause any pre-existing command to produce a 401,
+      480, or 483 response.
+
+
+
+
+
+Feather                     Standards Track                    [Page 17]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   o  A description of how the use of MODE READER on a mode-switching
+      server interacts with the extension.
+
+   o  A description of how support for the extension affects the
+      behaviour of a server and NNTP client in any other manner not
+      outlined above.
+
+   o  Formal syntax as described in Section 9.9.
+
+   A private extension MAY or MAY NOT be included in the capabilities
+   list.  If it is, the capability label MUST begin with "X".  A server
+   MAY provide additional keywords (for new commands and also for new
+   variants of existing commands) as part of a private extension.  To
+   avoid the risk of a clash with a future registered extension, these
+   keywords SHOULD begin with "X".
+
+   If the server advertises a capability defined by a registered
+   extension, it MUST implement the extension so as to fully conform
+   with the specification (for example, it MUST implement all the
+   commands that the extension describes as mandatory).  If it does not
+   implement the extension as specified, it MUST NOT list the extension
+   in the capabilities list under its registered name.  In that case, it
+   MAY, but SHOULD NOT, provide a private extension (not listed, or
+   listed with a different name) that implements part of the extension
+   or implements the commands of the extension with a different meaning.
+
+   A server MUST NOT send different response codes to basic NNTP
+   commands documented here or to commands documented in registered
+   extensions in response to the availability or use of a private
+   extension.
+
+3.3.4.  Initial IANA Register
+
+   IANA will maintain a registry of NNTP capability labels.  All
+   capability labels in the registry MUST be keywords and MUST NOT begin
+   with X.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 18]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   The initial content of the registry consists of these entries:
+
+   +-------------------+--------------------------+--------------------+
+   | Label             | Meaning                  | Definition         |
+   +-------------------+--------------------------+--------------------+
+   | AUTHINFO          | Authentication           | [NNTP-AUTH]        |
+   |                   |                          |                    |
+   | HDR               | Batched header retrieval | Section 3.3.2,     |
+   |                   |                          | Section 8.5, and   |
+   |                   |                          | Section 8.6        |
+   |                   |                          |                    |
+   | IHAVE             | IHAVE command available  | Section 3.3.2 and  |
+   |                   |                          | Section 6.3.2      |
+   |                   |                          |                    |
+   | IMPLEMENTATION    | Server                   | Section 3.3.2      |
+   |                   | implementation-specific  |                    |
+   |                   | information              |                    |
+   |                   |                          |                    |
+   | LIST              | LIST command variants    | Section 3.3.2 and  |
+   |                   |                          | Section 7.6.1      |
+   |                   |                          |                    |
+   | MODE-READER       | Mode-switching server    | Section 3.4.2      |
+   |                   | and MODE READER command  |                    |
+   |                   | available                |                    |
+   |                   |                          |                    |
+   | NEWNEWS           | NEWNEWS command          | Section 3.3.2 and  |
+   |                   | available                | Section 7.4        |
+   |                   |                          |                    |
+   | OVER              | Overview support         | Section 3.3.2,     |
+   |                   |                          | Section 8.3, and   |
+   |                   |                          | Section 8.4        |
+   |                   |                          |                    |
+   | POST              | POST command available   | Section 3.3.2 and  |
+   |                   |                          | Section 6.3.1      |
+   |                   |                          |                    |
+   | READER            | Reader commands          | Section 3.3.2      |
+   |                   | available                |                    |
+   |                   |                          |                    |
+   | SASL              | Supported SASL           | [NNTP-AUTH]        |
+   |                   | mechanisms               |                    |
+   |                   |                          |                    |
+   | STARTTLS          | Transport layer security | [NNTP-TLS]         |
+   |                   |                          |                    |
+   | STREAMING         | Streaming feeds          | [NNTP-STREAM]      |
+   |                   |                          |                    |
+   | VERSION           | Supported NNTP versions  | Section 3.3.2      |
+   +-------------------+--------------------------+--------------------+
+
+
+
+
+Feather                     Standards Track                    [Page 19]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+3.4.  Mandatory and Optional Commands
+
+   For a number of reasons, not all the commands in this specification
+   are mandatory.  However, it is equally undesirable for every command
+   to be optional, since this means that a client will have no idea what
+   facilities are available.  Therefore, as a compromise, some of the
+   commands in this specification are mandatory (they must be supported
+   by all servers) while the remainder are not.  The latter are then
+   subdivided into bundles, each indicated by a single capability label.
+
+   o  If the label is included in the capability list returned by the
+      server, the server MUST support all commands in that bundle.
+
+   o  If the label is not included, the server MAY support none or some
+      of the commands but SHOULD NOT support all of them.  In general,
+      there will be no way for a client to determine which commands are
+      supported without trying them.
+
+   The bundles have been chosen to provide useful functionality, and
+   therefore server authors are discouraged from implementing only part
+   of a bundle.
+
+   The description of each command will either indicate that it is
+   mandatory, or will give, using the term "indicating capability", the
+   capability label indicating whether the bundle including this command
+   is available.
+
+   Where a server does not implement a command, it MUST always generate
+   a 500 generic response code (or a 501 generic response code in the
+   case of a variant of a command depending on a second keyword where
+   the base command is recognised).  Otherwise, the command MUST be
+   fully implemented as specified; a server MUST NOT only partially
+   implement any of the commands in this specification.  (Client authors
+   should note that some servers not conforming to this specification
+   will return a 502 generic response code to some commands that are not
+   implemented.)
+
+   Note: some commands have cases that require other commands to be used
+   first.  If the former command is implemented but the latter is not,
+   the former MUST still generate the relevant specific response code.
+   For example, if ARTICLE (Section 6.2.1) is implemented but GROUP
+   (Section 6.1.1) is not, the correct response to "ARTICLE 1234"
+   remains 412.
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 20]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+3.4.1.  Reading and Transit Servers
+
+   NNTP is traditionally used in two different ways.  The first use is
+   "reading", where the client fetches articles from a large store
+   maintained by the server for immediate or later presentation to a
+   user and sends articles created by that user back to the server (an
+   action called "posting") to be stored and distributed to other stores
+   and users.  The second use is for the bulk transfer of articles from
+   one store to another.  Since the hosts making this transfer tend to
+   be peers in a network that transmit articles among one another, and
+   not end-user systems, this process is called "peering" or "transit".
+   (Even so, one host is still the client and the other is the server).
+
+   In practice, these two uses are so different that some server
+   implementations are optimised for reading or for transit and, as a
+   result, do not offer the other facility or only offer limited
+   features.  Other implementations are more general and offer both.
+   This specification allows for this by bundling the relevant commands
+   accordingly: the IHAVE command is designed for transit, while the
+   commands indicated by the READER capability are designed for reading
+   clients.
+
+   Except as an effect of the MODE READER command (Section 5.3) on a
+   mode-switching server, once a server advertises either or both of the
+   IHAVE or READER capabilities, it MUST continue to advertise them for
+   the entire session.
+
+   A server MAY provide different modes of behaviour (transit, reader,
+   or a combination) to different client connections and MAY use
+   external information, such as the IP address of the client, to
+   determine which mode to provide to any given connection.
+
+   The official TCP port for the NNTP service is 119.  However, if a
+   host wishes to offer separate servers for transit and reading
+   clients, port 433 SHOULD be used for the transit server and 119 for
+   the reading server.
+
+3.4.2.  Mode Switching
+
+   An implementation MAY, but SHOULD NOT, provide both transit and
+   reader facilities on the same server but require the client to select
+   which it wishes to use.  Such an arrangement is called a
+   "mode-switching" server.
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 21]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   A mode-switching server has two modes:
+
+   o  Transit mode, which applies after the initial connection.
+
+      *  It MUST advertise the MODE-READER capability.
+
+      *  It MUST NOT advertise the READER capability.
+
+      However, the server MAY cease to advertise the MODE-READER
+      capability after the client uses any command except CAPABILITIES.
+
+   o  Reading mode, after a successful MODE READER command (see Section
+      5.3).
+
+      *  It MUST NOT advertise the MODE-READER capability.
+
+      *  It MUST advertise the READER capability.
+
+      *  It MAY NOT advertise the IHAVE capability, even if it was
+         advertising it in transit mode.
+
+   A client SHOULD only issue a MODE READER command to a server if it is
+   advertising the MODE-READER capability.  If the server does not
+   support CAPABILITIES (and therefore does not conform to this
+   specification), the client MAY use the following heuristic:
+
+   o  If the client wishes to use any "reader" commands, it SHOULD use
+      the MODE READER command immediately after the initial connection.
+
+   o  Otherwise, it SHOULD NOT use the MODE READER command.
+
+   In each case, it should be prepared for some commands to be
+   unavailable that would have been available if it had made the other
+   choice.
+
+3.5.  Pipelining
+
+   NNTP is designed to operate over a reliable bi-directional
+   connection, such as TCP.  Therefore, if a command does not depend on
+   the response to the previous one, it should not matter if it is sent
+   before that response is received.  Doing this is called "pipelining".
+   However, certain server implementations throw away all text received
+   from the client following certain commands before sending their
+   response.  If this happens, pipelining will be affected because one
+   or more commands will have been ignored or misinterpreted, and the
+   client will be matching the wrong responses to each command.  Since
+   there are significant benefits to pipelining, but also circumstances
+   where it is reasonable or common for servers to behave in the above
+
+
+
+Feather                     Standards Track                    [Page 22]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   manner, this document puts certain requirements on both clients and
+   servers.
+
+   Except where stated otherwise, a client MAY use pipelining.  That is,
+   it may send a command before receiving the response for the previous
+   command.  The server MUST allow pipelining and MUST NOT throw away
+   any text received after a command.  Irrespective of whether
+   pipelining is used, the server MUST process commands in the order
+   they are sent.
+
+   If the specific description of a command says it "MUST NOT be
+   pipelined", that command MUST end any pipeline of commands.  That is,
+   the client MUST NOT send any following command until it receives the
+   CRLF at the end of the response from the command.  The server MAY
+   ignore any data received after the command and before the CRLF at the
+   end of the response is sent to the client.
+
+   The initial connection must not be part of a pipeline; that is, the
+   client MUST NOT send any command until it receives the CRLF at the
+   end of the greeting.
+
+   If the client uses blocking system calls to send commands, it MUST
+   ensure that the amount of text sent in pipelining does not cause a
+   deadlock between transmission and reception.  The amount of text
+   involved will depend on window sizes in the transmission layer;
+   typically, it is 4k octets for TCP.  (Since the server only sends
+   data in response to commands from the client, the converse problem
+   does not occur.)
+
+3.5.1.  Examples
+
+   Example of correct use of pipelining:
+
+      [C] GROUP misc.test
+      [C] STAT
+      [C] NEXT
+      [S] 211 1234 3000234 3002322 misc.test
+      [S] 223 3000234 <45223423@example.com> retrieved
+      [S] 223 3000237 <668929@example.org> retrieved
+
+   Example of incorrect use of pipelining (the MODE READER command may
+   not be pipelined):
+
+      [C] MODE READER
+      [C] DATE
+      [C] NEXT
+      [S] 200 Server ready, posting allowed
+      [S] 223 3000237 <668929@example.org> retrieved
+
+
+
+Feather                     Standards Track                    [Page 23]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   The DATE command has been thrown away by the server, so there is no
+   111 response to match it.
+
+3.6.  Articles
+
+   NNTP is intended to transfer articles between clients and servers.
+   For the purposes of this specification, articles are required to
+   conform to the rules in this section, and clients and servers MUST
+   correctly process any article received from the other that does so.
+   Note that this requirement applies only to the contents of
+   communications over NNTP; it does not prevent the client or server
+   from subsequently rejecting an article for reasons of local policy.
+   Also see Appendix A for further restrictions on the format of
+   articles in some uses of NNTP.
+
+   An article consists of two parts: the headers and the body.  They are
+   separated by a single empty line, or in other words by two
+   consecutive CRLF pairs (if there is more than one empty line, the
+   second and subsequent ones are part of the body).  In order to meet
+   the general requirements of NNTP, an article MUST NOT include the
+   octet NUL, MUST NOT contain the octets LF and CR other than as part
+   of a CRLF pair, and MUST end with a CRLF pair.  This specification
+   puts no further restrictions on the body; in particular, it MAY be
+   empty.
+
+   The headers of an article consist of one or more header lines.  Each
+   header line consists of a header name, a colon, a space, the header
+   content, and a CRLF, in that order.  The name consists of one or more
+   printable US-ASCII characters other than colon and, for the purposes
+   of this specification, is not case sensitive.  There MAY be more than
+   one header line with the same name.  The content MUST NOT contain
+   CRLF; it MAY be empty.  A header may be "folded"; that is, a CRLF
+   pair may be placed before any TAB or space in the line.  There MUST
+   still be some other octet between any two CRLF pairs in a header
+   line.  (Note that folding means that the header line occupies more
+   than one line when displayed or transmitted; nevertheless, it is
+   still referred to as "a" header line.)  The presence or absence of
+   folding does not affect the meaning of the header line; that is, the
+   CRLF pairs introduced by folding are not considered part of the
+   header content.  Header lines SHOULD NOT be folded before the space
+   after the colon that follows the header name and SHOULD include at
+   least one octet other than %x09 or %x20 between CRLF pairs.  However,
+   if an article that fails to satisfy this requirement has been
+   received from elsewhere, clients and servers MAY transfer it to each
+   other without re-folding it.
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 24]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   The content of a header SHOULD be in UTF-8.  However, if an
+   implementation receives an article from elsewhere that uses octets in
+   the range 128 to 255 in some other manner, it MAY pass it to a client
+   or server without modification.  Therefore, implementations MUST be
+   prepared to receive such headers, and data derived from them (e.g.,
+   in the responses from the OVER command, Section 8.3), and MUST NOT
+   assume that they are always UTF-8.  Any external processing of those
+   headers, including identifying the encoding used, is outside the
+   scope of this document.
+
+   Each article MUST have a unique message-id; two articles offered by
+   an NNTP server MUST NOT have the same message-id.  For the purposes
+   of this specification, message-ids are opaque strings that MUST meet
+   the following requirements:
+
+   o  A message-id MUST begin with "<", end with ">", and MUST NOT
+      contain the latter except at the end.
+
+   o  A message-id MUST be between 3 and 250 octets in length.
+
+   o  A message-id MUST NOT contain octets other than printable US-ASCII
+      characters.
+
+   Two message-ids are the same if and only if they consist of the same
+   sequence of octets.
+
+   This specification does not describe how the message-id of an article
+   is determined.  If the server does not have any way to determine a
+   message-id from the article itself, it MUST synthesize one (this
+   specification does not require that the article be changed as a
+   result).  See also Appendix A.2.
+
+4.  The WILDMAT Format
+
+   The WILDMAT format described here is based on the version first
+   developed by Rich Salz [SALZ1992], which was in turn derived from the
+   format used in the UNIX "find" command to articulate file names.  It
+   was developed to provide a uniform mechanism for matching patterns in
+   the same manner that the UNIX shell matches filenames.
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 25]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+4.1.  Wildmat Syntax
+
+   A wildmat is described by the following ABNF [RFC4234] syntax, which
+   is an extract of that in Section 9.8.
+
+     wildmat = wildmat-pattern *("," ["!"] wildmat-pattern)
+     wildmat-pattern = 1*wildmat-item
+     wildmat-item = wildmat-exact / wildmat-wild
+     wildmat-exact = %x22-29 / %x2B / %x2D-3E / %x40-5A / %x5E-7E /
+          UTF8-non-ascii ; exclude ! * , ? [ \ ]
+     wildmat-wild = "*" / "?"
+
+   Note: the characters ",", "\", "[", and "]" are not allowed in
+   wildmats, while * and ? are always wildcards.  This should not be a
+   problem, since these characters cannot occur in newsgroup names,
+   which is the only current use of wildmats.  Backslash is commonly
+   used to suppress the special meaning of characters, whereas brackets
+   are used to introduce sets.  However, these usages are not universal,
+   and interpretation of these characters in the context of UTF-8
+   strings is potentially complex and differs from existing practice, so
+   they were omitted from this specification.  A future extension to
+   this specification may provide semantics for these characters.
+
+4.2.  Wildmat Semantics
+
+   A wildmat is tested against a string and either matches or does not
+   match.  To do this, each constituent <wildmat-pattern> is matched
+   against the string, and the rightmost pattern that matches is
+   identified.  If that <wildmat-pattern> is not preceded with "!", the
+   whole wildmat matches.  If it is preceded by "!", or if no <wildmat-
+   pattern> matches, the whole wildmat does not match.
+
+   For example, consider the wildmat "a*,!*b,*c*":
+
+   o  The string "aaa" matches because the rightmost match is with "a*".
+
+   o  The string "abb" does not match because the rightmost match is
+      with "*b".
+
+   o  The string "ccb" matches because the rightmost match is with
+      "*c*".
+
+   o  The string "xxx" does not match because no <wildmat-pattern>
+      matches.
+
+   A <wildmat-pattern> matches a string if the string can be broken into
+   components, each of which matches the corresponding <wildmat-item> in
+   the pattern.  The matches must be in the same order, and the whole
+
+
+
+Feather                     Standards Track                    [Page 26]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   string must be used in the match.  The pattern is "anchored"; that
+   is, the first and last characters in the string must match the first
+   and last item, respectively (unless that item is an asterisk matching
+   zero characters).
+
+   A <wildmat-exact> matches the same character (which may be more than
+   one octet in UTF-8).
+
+   "?" matches exactly one character (which may be more than one octet).
+
+   "*" matches zero or more characters.  It can match an empty string,
+   but it cannot match a subsequence of a UTF-8 sequence that is not
+   aligned to the character boundaries.
+
+4.3.  Extensions
+
+   An NNTP server or extension MAY extend the syntax or semantics of
+   wildmats provided that all wildmats that meet the requirements of
+   Section 4.1 have the meaning ascribed to them by Section 4.2.  Future
+   editions of this document may also extend wildmats.
+
+4.4.  Examples
+
+   In these examples, $ and @ are used to represent the two octets %xC2
+   and %xA3, respectively; $@ is thus the UTF-8 encoding for the pound
+   sterling symbol, shown as # in the descriptions.
+
+     Wildmat    Description of strings that match
+       abc      The one string "abc"
+       abc,def  The two strings "abc" and "def"
+       $@       The one character string "#"
+       a*       Any string that begins with "a"
+       a*b      Any string that begins with "a" and ends with "b"
+       a*,*b    Any string that begins with "a" or ends with "b"
+       a*,!*b   Any string that begins with "a" and does not end with
+                "b"
+     a*,!*b,c*  Any string that begins with "a" and does not end with
+                "b", and any string that begins with "c" no matter
+                what it ends with
+     a*,c*,!*b  Any string that begins with "a" or "c" and does not
+                end with "b"
+       ?a*      Any string with "a" as its second character
+       ??a*     Any string with "a" as its third character
+       *a?      Any string with "a" as its penultimate character
+       *a??     Any string with "a" as its antepenultimate character
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 27]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+5.  Session Administration Commands
+
+5.1.  Initial Connection
+
+5.1.1.  Usage
+
+   This command MUST NOT be pipelined.
+
+   Responses [1]
+     200    Service available, posting allowed
+     201    Service available, posting prohibited
+     400    Service temporarily unavailable [2]
+     502    Service permanently unavailable [2]
+
+   [1] These are the only valid response codes for the initial greeting;
+       the server MUST not return any other generic response code.
+
+   [2] Following a 400 or 502 response, the server MUST immediately
+       close the connection.
+
+5.1.2.  Description
+
+   There is no command presented by the client upon initial connection
+   to the server.  The server MUST present an appropriate response code
+   as a greeting to the client.  This response informs the client
+   whether service is available and whether the client is permitted to
+   post.
+
+   If the server will accept further commands from the client including
+   POST, the server MUST present a 200 greeting code.  If the server
+   will accept further commands from the client, but the client is not
+   authorized to post articles using the POST command, the server MUST
+   present a 201 greeting code.
+
+   Otherwise, the server MUST present a 400 or 502 greeting code and
+   then immediately close the connection. 400 SHOULD be used if the
+   issue is only temporary (for example, because of load) and the client
+   can expect to be able to connect successfully at some point in the
+   future without making any changes. 502 MUST be used if the client is
+   not permitted under any circumstances to interact with the server,
+   and MAY be used if the server has insufficient information to
+   determine whether the issue is temporary or permanent.
+
+   Note: the distinction between the 200 and 201 response codes has
+   turned out in practice to be insufficient; for example, some servers
+   do not allow posting until the client has authenticated, while other
+   clients assume that a 201 response means that posting will never be
+   possible even after authentication.  Therefore, clients SHOULD use
+
+
+
+Feather                     Standards Track                    [Page 28]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   the CAPABILITIES command (Section 5.2) rather than rely on this
+   response.
+
+5.1.3.  Examples
+
+   Example of a normal connection from an authorized client that then
+   terminates the session (see Section 5.4):
+
+      [Initial connection set-up completed.]
+      [S] 200 NNTP Service Ready, posting permitted
+      [C] QUIT
+      [S] 205 NNTP Service exits normally
+      [Server closes connection.]
+
+   Example of a normal connection from an authorized client that is not
+   permitted to post, which also immediately terminates the session:
+
+      [Initial connection set-up completed.]
+      [S] 201 NNTP Service Ready, posting prohibited
+      [C] QUIT
+      [S] 205 NNTP Service exits normally
+      [Server closes connection.]
+
+   Example of a normal connection from an unauthorized client:
+
+      [Initial connection set-up completed.]
+      [S] 502 NNTP Service permanently unavailable
+      [Server closes connection.]
+
+   Example of a connection from a client if the server is unable to
+   provide service:
+
+      [Initial connection set-up completed.]
+      [S] 400 NNTP Service temporarily unavailable
+      [Server closes connection.]
+
+5.2.  CAPABILITIES
+
+5.2.1.  Usage
+
+   This command is mandatory.
+
+   Syntax
+     CAPABILITIES [keyword]
+
+   Responses
+     101    Capability list follows (multi-line)
+
+
+
+
+Feather                     Standards Track                    [Page 29]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Parameters
+     keyword    additional feature, see description
+
+5.2.2.  Description
+
+   The CAPABILITIES command allows a client to determine the
+   capabilities of the server at any given time.
+
+   This command MAY be issued at any time; the server MUST NOT require
+   it to be issued in order to make use of any capability.  The response
+   generated by this command MAY change during a session because of
+   other state information (which, in turn, may be changed by the
+   effects of other commands or by external events).  An NNTP client is
+   only able to get the current and correct information concerning
+   available capabilities at any point during a session by issuing a
+   CAPABILITIES command at that point of that session and processing the
+   response.
+
+   The capability list is returned as a multi-line data block following
+   the 101 response code.  Each capability is described by a separate
+   capability line.  The server MUST NOT list the same capability twice
+   in the response, even with different arguments.  Except that the
+   VERSION capability MUST be the first line, the order in which the
+   capability lines appears is not significant; the server need not even
+   consistently return the same order.
+
+   While some capabilities are likely to be always available or never
+   available, others (notably extensions) will appear and disappear
+   depending on server state changes within the session or on external
+   events between sessions.  An NNTP client MAY cache the results of
+   this command, but MUST NOT rely on the correctness of any cached
+   results, whether from earlier in this session or from a previous
+   session, MUST cope gracefully with the cached status being out of
+   date, and SHOULD (if caching results) provide a way to force the
+   cached information to be refreshed.  Furthermore, a client MUST NOT
+   use cached results in relation to security, privacy, and
+   authentication extensions.  See Section 12.6 for further discussion
+   of this topic.
+
+   The keyword argument is not used by this specification.  It is
+   provided so that extensions or revisions to this specification can
+   include extra features for this command without requiring the
+   CAPABILITIES command to be used twice (once to determine if the extra
+   features are available, and a second time to make use of them).  If
+   the server does not recognise the argument (and it is a keyword), it
+   MUST respond with the 101 response code as if the argument had been
+   omitted.  If an argument is provided that the server does recognise,
+   it MAY use the 101 response code or MAY use some other response code
+
+
+
+Feather                     Standards Track                    [Page 30]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   (which will be defined in the specification of that feature).  If the
+   argument is not a keyword, the 501 generic response code MUST be
+   returned.  The server MUST NOT generate any other response code to
+   the CAPABILITIES command.
+
+5.2.3.  Examples
+
+   Example of a minimal response (a read-only server):
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+
+   Example of a response from a server that has a range of facilities
+   and that also describes itself:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] IHAVE
+      [S] POST
+      [S] NEWNEWS
+      [S] LIST ACTIVE NEWSGROUPS ACTIVE.TIMES OVERVIEW.FMT
+      [S] IMPLEMENTATION INN 4.2 2004-12-25
+      [S] OVER MSGID
+      [S] STREAMING
+      [S] XSECRET
+      [S] .
+
+   Example of a server that supports more than one version of NNTP:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2 3
+      [S] READER
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 31]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of a client attempting to use a feature of the CAPABILITIES
+   command that the server does not support:
+
+      [C] CAPABILITIES AUTOUPDATE
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] IHAVE
+      [S] LIST ACTIVE NEWSGROUPS OVERVIEW.FMT HEADERS
+      [S] OVER MSGID
+      [S] HDR
+      [S] NEWNEWS
+      [S] .
+
+5.3.  MODE READER
+
+5.3.1.  Usage
+
+   Indicating capability: MODE-READER
+
+   This command MUST NOT be pipelined.
+
+   Syntax
+     MODE READER
+
+   Responses
+     200    Posting allowed
+     201    Posting prohibited
+     502    Reading service permanently unavailable [1]
+
+   [1] Following a 502 response the server MUST immediately close the
+       connection.
+
+5.3.2.  Description
+
+   The MODE READER command instructs a mode-switching server to switch
+   modes, as described in Section 3.4.2.
+
+   If the server is mode-switching, it switches from its transit mode to
+   its reader mode, indicating this by changing the capability list
+   accordingly.  It MUST then return a 200 or 201 response with the same
+   meaning as for the initial greeting (as described in Section 5.1.1).
+   Note that the response need not be the same as that presented during
+   the initial greeting.  The client MUST NOT issue MODE READER more
+   than once in a session or after any security or privacy commands are
+   issued.  When the MODE READER command is issued, the server MAY reset
+   its state to that immediately after the initial connection before
+   switching mode.
+
+
+
+Feather                     Standards Track                    [Page 32]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   If the server is not mode-switching, then the following apply:
+
+   o  If it advertises the READER capability, it MUST return a 200 or
+      201 response with the same meaning as for the initial greeting; in
+      this case, the command MUST NOT affect the server state in any
+      way.
+
+   o  If it does not advertise the READER capability, it MUST return a
+      502 response and then immediately close the connection.
+
+5.3.3.  Examples
+
+   Example of use of the MODE READER command on a transit-only server
+   (which therefore does not providing reading facilities):
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] IHAVE
+      [S] .
+      [C] MODE READER
+      [S] 502 Transit service only
+      [Server closes connection.]
+
+   Example of use of the MODE READER command on a server that provides
+   reading facilities:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+      [C] MODE READER
+      [S] 200 Reader mode, posting permitted
+      [C] IHAVE <i.am.an.article.you.have@example.com>
+      [S] 500 Permission denied
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+
+   Note that in both of these situations, the client SHOULD NOT use MODE
+   READER.
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 33]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of use of the MODE READER command on a mode-switching server:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] IHAVE
+      [S] MODE-READER
+      [S] .
+      [C] MODE READER
+      [S] 200 Reader mode, posting permitted
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] NEWNEWS
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] STARTTLS
+      [S] .
+
+   In this case, the server offers (but does not require) TLS privacy in
+   its reading mode but not in its transit mode.
+
+   Example of use of the MODE READER command where the client is not
+   permitted to post:
+
+      [C] MODE READER
+      [S] 201 NNTP Service Ready, posting prohibited
+
+5.4.  QUIT
+
+5.4.1.  Usage
+
+   This command is mandatory.
+
+   Syntax
+     QUIT
+
+   Responses
+     205    Connection closing
+
+5.4.2.  Description
+
+   The client uses the QUIT command to terminate the session.  The
+   server MUST acknowledge the QUIT command and then close the
+   connection to the client.  This is the preferred method for a client
+   to indicate that it has finished all of its transactions with the
+   NNTP server.
+
+
+
+
+Feather                     Standards Track                    [Page 34]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   If a client simply disconnects (or if the connection times out or
+   some other fault occurs), the server MUST gracefully cease its
+   attempts to service the client, disconnecting from its end if
+   necessary.
+
+   The server MUST NOT generate any response code to the QUIT command
+   other than 205 or, if any arguments are provided, 501.
+
+5.4.3.  Examples
+
+      [C] QUIT
+      [S] 205 closing connection
+      [Server closes connection.]
+
+6.  Article Posting and Retrieval
+
+   News-reading clients have available a variety of mechanisms to
+   retrieve articles via NNTP.  The news articles are stored and indexed
+   using three types of keys.  The first type of key is the message-id
+   of an article and is globally unique.  The second type of key is
+   composed of a newsgroup name and an article number within that
+   newsgroup.  On a particular server, there MUST only be one article
+   with a given number within any newsgroup, and an article MUST NOT
+   have two different numbers in the same newsgroup.  An article can be
+   cross-posted to multiple newsgroups, so there may be multiple keys
+   that point to the same article on the same server; these MAY have
+   different numbers in each newsgroup.  However, this type of key is
+   not required to be globally unique, so the same key MAY refer to
+   different articles on different servers.  (Note that the terms
+   "group" and "newsgroup" are equivalent.)
+
+   The final type of key is the arrival timestamp, giving the time that
+   the article arrived at the server.  The server MUST ensure that
+   article numbers are issued in order of arrival timestamp; that is,
+   articles arriving later MUST have higher numbers than those that
+   arrive earlier.  The server SHOULD allocate the next sequential
+   unused number to each new article.
+
+   Article numbers MUST lie between 1 and 2,147,483,647, inclusive.  The
+   client and server MAY use leading zeroes in specifying article
+   numbers but MUST NOT use more than 16 digits.  In some situations,
+   the value zero replaces an article number to show some special
+   situation.
+
+   Note that it is likely that the article number limit of 2,147,483,647
+   will be increased by a future revision or extension to this
+   specification.  While servers MUST NOT send article numbers greater
+   than this current limit, client and server developers are advised to
+
+
+
+Feather                     Standards Track                    [Page 35]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   use internal structures and datatypes capable of handling larger
+   values in anticipation of such a change.
+
+6.1.  Group and Article Selection
+
+   The following commands are used to set the "currently selected
+   newsgroup" and the "current article number", which are used by
+   various commands.  At the start of an NNTP session, both of these
+   values are set to the special value "invalid".
+
+6.1.1.  GROUP
+
+6.1.1.1.  Usage
+
+   Indicating capability: READER
+
+   Syntax
+     GROUP group
+
+   Responses
+     211 number low high group     Group successfully selected
+     411                           No such newsgroup
+
+   Parameters
+     group     Name of newsgroup
+     number    Estimated number of articles in the group
+     low       Reported low water mark
+     high      Reported high water mark
+
+6.1.1.2.  Description
+
+   The GROUP command selects a newsgroup as the currently selected
+   newsgroup and returns summary information about it.
+
+   The required argument is the name of the newsgroup to be selected
+   (e.g., "news.software.nntp").  A list of valid newsgroups may be
+   obtained by using the LIST ACTIVE command (see Section 7.6.3).
+
+   The successful selection response will return the article numbers of
+   the first and last articles in the group at the moment of selection
+   (these numbers are referred to as the "reported low water mark" and
+   the "reported high water mark") and an estimate of the number of
+   articles in the group currently available.
+
+   If the group is not empty, the estimate MUST be at least the actual
+   number of articles available and MUST be no greater than one more
+   than the difference between the reported low and high water marks.
+   (Some implementations will actually count the number of articles
+
+
+
+Feather                     Standards Track                    [Page 36]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   currently stored.  Others will just subtract the low water mark from
+   the high water mark and add one to get an estimate.)
+
+   If the group is empty, one of the following three situations will
+   occur.  Clients MUST accept all three cases; servers MUST NOT
+   represent an empty group in any other way.
+
+   o  The high water mark will be one less than the low water mark, and
+      the estimated article count will be zero.  Servers SHOULD use this
+      method to show an empty group.  This is the only time that the
+      high water mark can be less than the low water mark.
+
+   o  All three numbers will be zero.
+
+   o  The high water mark is greater than or equal to the low water
+      mark.  The estimated article count might be zero or non-zero; if
+      it is non-zero, the same requirements apply as for a non-empty
+      group.
+
+   The set of articles in a group may change after the GROUP command is
+   carried out:
+
+   o  Articles may be removed from the group.
+
+   o  Articles may be reinstated in the group with the same article
+      number, but those articles MUST have numbers no less than the
+      reported low water mark (note that this is a reinstatement of the
+      previous article, not a new article reusing the number).
+
+   o  New articles may be added with article numbers greater than the
+      reported high water mark.  (If an article that was the one with
+      the highest number has been removed and the high water mark has
+      been adjusted accordingly, the next new article will not have the
+      number one greater than the reported high water mark.)
+
+   Except when the group is empty and all three numbers are zero,
+   whenever a subsequent GROUP command for the same newsgroup is issued,
+   either by the same client or a different client, the reported low
+   water mark in the response MUST be no less than that in any previous
+   response for that newsgroup in this session, and it SHOULD be no less
+   than that in any previous response for that newsgroup ever sent to
+   any client.  Any failure to meet the latter condition SHOULD be
+   transient only.  The client may make use of the low water mark to
+   remove all remembered information about articles with lower numbers,
+   as these will never recur.  This includes the situation when the high
+   water mark is one less than the low water mark.  No similar
+   assumption can be made about the high water mark, as this can
+
+
+
+
+Feather                     Standards Track                    [Page 37]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   decrease if an article is removed and then increase again if it is
+   reinstated or if new articles arrive.
+
+   When a valid group is selected by means of this command, the
+   currently selected newsgroup MUST be set to that group, and the
+   current article number MUST be set to the first article in the group
+   (this applies even if the group is already the currently selected
+   newsgroup).  If an empty newsgroup is selected, the current article
+   number is made invalid.  If an invalid group is specified, the
+   currently selected newsgroup and current article number MUST NOT be
+   changed.
+
+   The GROUP or LISTGROUP command (see Section 6.1.2) MUST be used by a
+   client, and a successful response received, before any other command
+   is used that depends on the value of the currently selected newsgroup
+   or current article number.
+
+   If the group specified is not available on the server, a 411 response
+   MUST be returned.
+
+6.1.1.3.  Examples
+
+   Example for a group known to the server:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+
+   Example for a group unknown to the server:
+
+      [C] GROUP example.is.sob.bradner.or.barber
+      [S] 411 example.is.sob.bradner.or.barber is unknown
+
+   Example of an empty group using the preferred response:
+
+      [C] GROUP example.currently.empty.newsgroup
+      [S] 211 0 4000 3999 example.currently.empty.newsgroup
+
+   Example of an empty group using an alternative response:
+
+      [C] GROUP example.currently.empty.newsgroup
+      [S] 211 0 0 0 example.currently.empty.newsgroup
+
+   Example of an empty group using a different alternative response:
+
+      [C] GROUP example.currently.empty.newsgroup
+      [S] 211 0 4000 4321 example.currently.empty.newsgroup
+
+
+
+
+
+Feather                     Standards Track                    [Page 38]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example reselecting the currently selected newsgroup:
+
+      [C] GROUP misc.test
+      [S] 211 1234 234 567 misc.test
+      [C] STAT 444
+      [S] 223 444 <123456@example.net> retrieved
+      [C] GROUP misc.test
+      [S] 211 1234 234 567 misc.test
+      [C] STAT
+      [S] 223 234 <different@example.net> retrieved
+
+6.1.2.  LISTGROUP
+
+6.1.2.1.  Usage
+
+   Indicating capability: READER
+
+   Syntax
+     LISTGROUP [group [range]]
+
+   Responses
+     211 number low high group     Article numbers follow (multi-line)
+     411                           No such newsgroup
+     412                           No newsgroup selected [1]
+
+   Parameters
+     group     Name of newsgroup
+     range     Range of articles to report
+     number    Estimated number of articles in the group
+     low       Reported low water mark
+     high      Reported high water mark
+
+   [1] The 412 response can only occur if no group has been specified.
+
+6.1.2.2.  Description
+
+   The LISTGROUP command selects a newsgroup in the same manner as the
+   GROUP command (see Section 6.1.1) but also provides a list of article
+   numbers in the newsgroup.  If no group is specified, the currently
+   selected newsgroup is used.
+
+   On success, a list of article numbers is returned as a multi-line
+   data block following the 211 response code (the arguments on the
+   initial response line are the same as for the GROUP command).  The
+   list contains one number per line and is in numerical order.  It
+   lists precisely those articles that exist in the group at the moment
+   of selection (therefore, an empty group produces an empty list).  If
+   the optional range argument is specified, only articles within the
+
+
+
+Feather                     Standards Track                    [Page 39]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   range are included in the list (therefore, the list MAY be empty even
+   if the group is not).
+
+   The range argument may be any of the following:
+
+   o  An article number.
+
+   o  An article number followed by a dash to indicate all following.
+
+   o  An article number followed by a dash followed by another article
+      number.
+
+   In the last case, if the second number is less than the first number,
+   then the range contains no articles.  Omitting the range is
+   equivalent to the range 1- being specified.
+
+   If the group specified is not available on the server, a 411 response
+   MUST be returned.  If no group is specified and the currently
+   selected newsgroup is invalid, a 412 response MUST be returned.
+
+   Except that the group argument is optional, that a range argument can
+   be specified, and that a multi-line data block follows the 211
+   response code, the LISTGROUP command is identical to the GROUP
+   command.  In particular, when successful, the command sets the
+   current article number to the first article in the group, if any,
+   even if this is not within the range specified by the second
+   argument.
+
+   Note that the range argument is a new feature in this specification
+   and servers that do not support CAPABILITIES (and therefore do not
+   conform to this specification) are unlikely to support it.
+
+6.1.2.3.  Examples
+
+   Example of LISTGROUP being used to select a group:
+
+      [C] LISTGROUP misc.test
+      [S] 211 2000 3000234 3002322 misc.test list follows
+      [S] 3000234
+      [S] 3000237
+      [S] 3000238
+      [S] 3000239
+      [S] 3002322
+      [S] .
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 40]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of LISTGROUP on an empty group:
+
+      [C] LISTGROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup list follows
+      [S] .
+
+   Example of LISTGROUP on a valid, currently selected newsgroup:
+
+      [C] GROUP misc.test
+      [S] 211 2000 3000234 3002322 misc.test
+      [C] LISTGROUP
+      [S] 211 2000 3000234 3002322 misc.test list follows
+      [S] 3000234
+      [S] 3000237
+      [S] 3000238
+      [S] 3000239
+      [S] 3002322
+      [S] .
+
+   Example of LISTGROUP with a range:
+
+      [C] LISTGROUP misc.test 3000238-3000248
+      [S] 211 2000 3000234 3002322 misc.test list follows
+      [S] 3000238
+      [S] 3000239
+      [S] .
+
+   Example of LISTGROUP with an empty range:
+
+      [C] LISTGROUP misc.test 12345678-
+      [S] 211 2000 3000234 3002322 misc.test list follows
+      [S] .
+
+   Example of LISTGROUP with an invalid range:
+
+      [C] LISTGROUP misc.test 9999-111
+      [S] 211 2000 3000234 3002322 misc.test list follows
+      [S] .
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 41]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+6.1.3.  LAST
+
+6.1.3.1.  Usage
+
+   Indicating capability: READER
+
+   Syntax
+     LAST
+
+   Responses
+     223 n message-id    Article found
+     412                 No newsgroup selected
+     420                 Current article number is invalid
+     422                 No previous article in this group
+
+   Parameters
+     n             Article number
+     message-id    Article message-id
+
+6.1.3.2.  Description
+
+   If the currently selected newsgroup is valid, the current article
+   number MUST be set to the previous article in that newsgroup (that
+   is, the highest existing article number less than the current article
+   number).  If successful, a response indicating the new current
+   article number and the message-id of that article MUST be returned.
+   No article text is sent in response to this command.
+
+   There MAY be no previous article in the group, although the current
+   article number is not the reported low water mark.  There MUST NOT be
+   a previous article when the current article number is the reported
+   low water mark.
+
+   Because articles can be removed and added, the results of multiple
+   LAST and NEXT commands MAY not be consistent over the life of a
+   particular NNTP session.
+
+   If the current article number is already the first article of the
+   newsgroup, a 422 response MUST be returned.  If the current article
+   number is invalid, a 420 response MUST be returned.  If the currently
+   selected newsgroup is invalid, a 412 response MUST be returned.  In
+   all three cases, the currently selected newsgroup and current article
+   number MUST NOT be altered.
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 42]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+6.1.3.3.  Examples
+
+   Example of a successful article retrieval using LAST:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] NEXT
+      [S] 223 3000237 <668929@example.org> retrieved
+      [C] LAST
+      [S] 223 3000234 <45223423@example.com> retrieved
+
+   Example of an attempt to retrieve an article without having selected
+   a group (via the GROUP command) first:
+
+      [Assumes currently selected newsgroup is invalid.]
+      [C] LAST
+      [S] 412 no newsgroup selected
+
+   Example of an attempt to retrieve an article using the LAST command
+   when the current article number is that of the first article in the
+   group:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] LAST
+      [S] 422 No previous article to retrieve
+
+   Example of an attempt to retrieve an article using the LAST command
+   when the currently selected newsgroup is empty:
+
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] LAST
+      [S] 420 No current article selected
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 43]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+6.1.4.  NEXT
+
+6.1.4.1.  Usage
+
+   Indicating capability: READER
+
+   Syntax
+     NEXT
+
+   Responses
+     223 n message-id    Article found
+     412                 No newsgroup selected
+     420                 Current article number is invalid
+     421                 No next article in this group
+
+   Parameters
+     n             Article number
+     message-id    Article message-id
+
+6.1.4.2.  Description
+
+   If the currently selected newsgroup is valid, the current article
+   number MUST be set to the next article in that newsgroup (that is,
+   the lowest existing article number greater than the current article
+   number).  If successful, a response indicating the new current
+   article number and the message-id of that article MUST be returned.
+   No article text is sent in response to this command.
+
+   If the current article number is already the last article of the
+   newsgroup, a 421 response MUST be returned.  In all other aspects
+   (apart, of course, from the lack of 422 response), this command is
+   identical to the LAST command (Section 6.1.3).
+
+6.1.4.3.  Examples
+
+   Example of a successful article retrieval using NEXT:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] NEXT
+      [S] 223 3000237 <668929@example.org> retrieved
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 44]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of an attempt to retrieve an article without having selected
+   a group (via the GROUP command) first:
+
+      [Assumes currently selected newsgroup is invalid.]
+      [C] NEXT
+      [S] 412 no newsgroup selected
+
+   Example of an attempt to retrieve an article using the NEXT command
+   when the current article number is that of the last article in the
+   group:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] STAT 3002322
+      [S] 223 3002322 <411@example.net> retrieved
+      [C] NEXT
+      [S] 421 No next article to retrieve
+
+   Example of an attempt to retrieve an article using the NEXT command
+   when the currently selected newsgroup is empty:
+
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] NEXT
+      [S] 420 No current article selected
+
+6.2.  Retrieval of Articles and Article Sections
+
+   The ARTICLE, BODY, HEAD, and STAT commands are very similar.  They
+   differ only in the parts of the article that are presented to the
+   client and in the successful response code.  The ARTICLE command is
+   described here in full, while the other three commands are described
+   in terms of the differences.  As specified in Section 3.6, an article
+   consists of two parts: the article headers and the article body.
+
+   When responding to one of these commands, the server MUST present the
+   entire article or appropriate part and MUST NOT attempt to alter or
+   translate it in any way.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 45]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+6.2.1.  ARTICLE
+
+6.2.1.1.  Usage
+
+   Indicating capability: READER
+
+   Syntax
+     ARTICLE message-id
+     ARTICLE number
+     ARTICLE
+
+   Responses
+
+   First form (message-id specified)
+     220 0|n message-id    Article follows (multi-line)
+     430                   No article with that message-id
+
+   Second form (article number specified)
+     220 n message-id      Article follows (multi-line)
+     412                   No newsgroup selected
+     423                   No article with that number
+
+   Third form (current article number used)
+     220 n message-id      Article follows (multi-line)
+     412                   No newsgroup selected
+     420                   Current article number is invalid
+
+   Parameters
+     number        Requested article number
+     n             Returned article number
+     message-id    Article message-id
+
+6.2.1.2.  Description
+
+   The ARTICLE command selects an article according to the arguments and
+   presents the entire article (that is, the headers, an empty line, and
+   the body, in that order) to the client.  The command has three forms.
+
+   In the first form, a message-id is specified, and the server presents
+   the article with that message-id.  In this case, the server MUST NOT
+   alter the currently selected newsgroup or current article number.
+   This is both to facilitate the presentation of articles that may be
+   referenced within another article being read, and because of the
+   semantic difficulties of determining the proper sequence and
+   membership of an article that may have been cross-posted to more than
+   one newsgroup.
+
+
+
+
+
+Feather                     Standards Track                    [Page 46]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   In the response, the article number MUST be replaced with zero,
+   unless there is a currently selected newsgroup and the article is
+   present in that group, in which case the server MAY use the article's
+   number in that group.  (The server is not required to determine
+   whether the article is in the currently selected newsgroup or, if so,
+   what article number it has; the client MUST always be prepared for
+   zero to be specified.)  The server MUST NOT provide an article number
+   unless use of that number in a second ARTICLE command immediately
+   following this one would return the same article.  Even if the server
+   chooses to return article numbers in these circumstances, it need not
+   do so consistently; it MAY return zero to any such command (also see
+   the STAT examples, Section 6.2.4.3).
+
+   In the second form, an article number is specified.  If there is an
+   article with that number in the currently selected newsgroup, the
+   server MUST set the current article number to that number.
+
+   In the third form, the article indicated by the current article
+   number in the currently selected newsgroup is used.
+
+   Note that a previously valid article number MAY become invalid if the
+   article has been removed.  A previously invalid article number MAY
+   become valid if the article has been reinstated, but this article
+   number MUST be no less than the reported low water mark for that
+   group.
+
+   The server MUST NOT change the currently selected newsgroup as a
+   result of this command.  The server MUST NOT change the current
+   article number except when an article number argument was provided
+   and the article exists; in particular, it MUST NOT change it
+   following an unsuccessful response.
+
+   Since the message-id is unique for each article, it may be used by a
+   client to skip duplicate displays of articles that have been posted
+   more than once, or to more than one newsgroup.
+
+   The article is returned as a multi-line data block following the 220
+   response code.
+
+   If the argument is a message-id and no such article exists, a 430
+   response MUST be returned.  If the argument is a number or is omitted
+   and the currently selected newsgroup is invalid, a 412 response MUST
+   be returned.  If the argument is a number and that article does not
+   exist in the currently selected newsgroup, a 423 response MUST be
+   returned.  If the argument is omitted and the current article number
+   is invalid, a 420 response MUST be returned.
+
+
+
+
+
+Feather                     Standards Track                    [Page 47]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+6.2.1.3.  Examples
+
+   Example of a successful retrieval of an article (explicitly not using
+   an article number):
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] ARTICLE
+      [S] 220 3000234 <45223423@example.com>
+      [S] Path: pathost!demo!whitehouse!not-for-mail
+      [S] From: "Demo User" <nobody@example.net>
+      [S] Newsgroups: misc.test
+      [S] Subject: I am just a test article
+      [S] Date: 6 Oct 1998 04:38:40 -0500
+      [S] Organization: An Example Net, Uncertain, Texas
+      [S] Message-ID: <45223423@example.com>
+      [S]
+      [S] This is just a test article.
+      [S] .
+
+   Example of a successful retrieval of an article by message-id:
+
+      [C] ARTICLE <45223423@example.com>
+      [S] 220 0 <45223423@example.com>
+      [S] Path: pathost!demo!whitehouse!not-for-mail
+      [S] From: "Demo User" <nobody@example.net>
+      [S] Newsgroups: misc.test
+      [S] Subject: I am just a test article
+      [S] Date: 6 Oct 1998 04:38:40 -0500
+      [S] Organization: An Example Net, Uncertain, Texas
+      [S] Message-ID: <45223423@example.com>
+      [S]
+      [S] This is just a test article.
+      [S] .
+
+   Example of an unsuccessful retrieval of an article by message-id:
+
+      [C] ARTICLE <i.am.not.there@example.com>
+      [S] 430 No Such Article Found
+
+   Example of an unsuccessful retrieval of an article by number:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 news.groups
+      [C] ARTICLE 300256
+      [S] 423 No article with that number
+
+
+
+
+
+Feather                     Standards Track                    [Page 48]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of an unsuccessful retrieval of an article by number because
+   no newsgroup was selected first:
+
+      [Assumes currently selected newsgroup is invalid.]
+      [C] ARTICLE 300256
+      [S] 412 No newsgroup selected
+
+   Example of an attempt to retrieve an article when the currently
+   selected newsgroup is empty:
+
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] ARTICLE
+      [S] 420 No current article selected
+
+6.2.2.  HEAD
+
+6.2.2.1.  Usage
+
+   This command is mandatory.
+
+   Syntax
+     HEAD message-id
+     HEAD number
+     HEAD
+
+   Responses
+
+   First form (message-id specified)
+     221 0|n message-id    Headers follow (multi-line)
+     430                   No article with that message-id
+
+   Second form (article number specified)
+     221 n message-id      Headers follow (multi-line)
+     412                   No newsgroup selected
+     423                   No article with that number
+
+   Third form (current article number used)
+     221 n message-id      Headers follow (multi-line)
+     412                   No newsgroup selected
+     420                   Current article number is invalid
+
+   Parameters
+     number        Requested article number
+     n             Returned article number
+     message-id    Article message-id
+
+
+
+
+
+Feather                     Standards Track                    [Page 49]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+6.2.2.2.  Description
+
+   The HEAD command behaves identically to the ARTICLE command except
+   that, if the article exists, the response code is 221 instead of 220
+   and only the headers are presented (the empty line separating the
+   headers and body MUST NOT be included).
+
+6.2.2.3.  Examples
+
+   Example of a successful retrieval of the headers of an article
+   (explicitly not using an article number):
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] HEAD
+      [S] 221 3000234 <45223423@example.com>
+      [S] Path: pathost!demo!whitehouse!not-for-mail
+      [S] From: "Demo User" <nobody@example.net>
+      [S] Newsgroups: misc.test
+      [S] Subject: I am just a test article
+      [S] Date: 6 Oct 1998 04:38:40 -0500
+      [S] Organization: An Example Net, Uncertain, Texas
+      [S] Message-ID: <45223423@example.com>
+      [S] .
+
+   Example of a successful retrieval of the headers of an article by
+   message-id:
+
+      [C] HEAD <45223423@example.com>
+      [S] 221 0 <45223423@example.com>
+      [S] Path: pathost!demo!whitehouse!not-for-mail
+      [S] From: "Demo User" <nobody@example.net>
+      [S] Newsgroups: misc.test
+      [S] Subject: I am just a test article
+      [S] Date: 6 Oct 1998 04:38:40 -0500
+      [S] Organization: An Example Net, Uncertain, Texas
+      [S] Message-ID: <45223423@example.com>
+      [S] .
+
+   Example of an unsuccessful retrieval of the headers of an article by
+   message-id:
+
+      [C] HEAD <i.am.not.there@example.com>
+      [S] 430 No Such Article Found
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 50]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of an unsuccessful retrieval of the headers of an article by
+   number:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] HEAD 300256
+      [S] 423 No article with that number
+
+   Example of an unsuccessful retrieval of the headers of an article by
+   number because no newsgroup was selected first:
+
+      [Assumes currently selected newsgroup is invalid.]
+      [C] HEAD 300256
+      [S] 412 No newsgroup selected
+
+   Example of an attempt to retrieve the headers of an article when the
+   currently selected newsgroup is empty:
+
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] HEAD
+      [S] 420 No current article selected
+
+6.2.3.  BODY
+
+6.2.3.1.  Usage
+
+   Indicating capability: READER
+
+   Syntax
+     BODY message-id
+     BODY number
+     BODY
+
+   Responses
+
+   First form (message-id specified)
+     222 0|n message-id    Body follows (multi-line)
+     430                   No article with that message-id
+
+   Second form (article number specified)
+     222 n message-id      Body follows (multi-line)
+     412                   No newsgroup selected
+     423                   No article with that number
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 51]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Third form (current article number used)
+     222 n message-id      Body follows (multi-line)
+     412                   No newsgroup selected
+     420                   Current article number is invalid
+
+   Parameters
+     number        Requested article number
+     n             Returned article number
+     message-id    Article message-id
+
+6.2.3.2.  Description
+
+   The BODY command behaves identically to the ARTICLE command except
+   that, if the article exists, the response code is 222 instead of 220
+   and only the body is presented (the empty line separating the headers
+   and body MUST NOT be included).
+
+6.2.3.3.  Examples
+
+   Example of a successful retrieval of the body of an article
+   (explicitly not using an article number):
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] BODY
+      [S] 222 3000234 <45223423@example.com>
+      [S] This is just a test article.
+      [S] .
+
+   Example of a successful retrieval of the body of an article by
+   message-id:
+
+      [C] BODY <45223423@example.com>
+      [S] 222 0 <45223423@example.com>
+      [S] This is just a test article.
+      [S] .
+
+   Example of an unsuccessful retrieval of the body of an article by
+   message-id:
+
+      [C] BODY <i.am.not.there@example.com>
+      [S] 430 No Such Article Found
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 52]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of an unsuccessful retrieval of the body of an article by
+   number:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] BODY 300256
+      [S] 423 No article with that number
+
+   Example of an unsuccessful retrieval of the body of an article by
+   number because no newsgroup was selected first:
+
+      [Assumes currently selected newsgroup is invalid.]
+      [C] BODY 300256
+      [S] 412 No newsgroup selected
+
+   Example of an attempt to retrieve the body of an article when the
+   currently selected newsgroup is empty:
+
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] BODY
+      [S] 420 No current article selected
+
+6.2.4.  STAT
+
+6.2.4.1.  Usage
+
+   This command is mandatory.
+
+   Syntax
+     STAT message-id
+     STAT number
+     STAT
+
+   Responses
+
+   First form (message-id specified)
+     223 0|n message-id    Article exists
+     430                   No article with that message-id
+
+   Second form (article number specified)
+     223 n message-id      Article exists
+     412                   No newsgroup selected
+     423                   No article with that number
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 53]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Third form (current article number used)
+     223 n message-id      Article exists
+     412                   No newsgroup selected
+     420                   Current article number is invalid
+
+   Parameters
+     number        Requested article number
+     n             Returned article number
+     message-id    Article message-id
+
+6.2.4.2.  Description
+
+   The STAT command behaves identically to the ARTICLE command except
+   that, if the article exists, it is NOT presented to the client and
+   the response code is 223 instead of 220.  Note that the response is
+   NOT multi-line.
+
+   This command allows the client to determine whether an article exists
+   and, in the second and third forms, what its message-id is, without
+   having to process an arbitrary amount of text.
+
+6.2.4.3.  Examples
+
+   Example of STAT on an existing article (explicitly not using an
+   article number):
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] STAT
+      [S] 223 3000234 <45223423@example.com>
+
+   Example of STAT on an existing article by message-id:
+
+      [C] STAT <45223423@example.com>
+      [S] 223 0 <45223423@example.com>
+
+   Example of STAT on an article not on the server by message-id:
+
+      [C] STAT <i.am.not.there@example.com>
+      [S] 430 No Such Article Found
+
+   Example of STAT on an article not in the server by number:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] STAT 300256
+      [S] 423 No article with that number
+
+
+
+
+Feather                     Standards Track                    [Page 54]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of STAT on an article by number when no newsgroup was
+   selected first:
+
+      [Assumes currently selected newsgroup is invalid.]
+      [C] STAT 300256
+      [S] 412 No newsgroup selected
+
+   Example of STAT on an article when the currently selected newsgroup
+   is empty:
+
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] STAT
+      [S] 420 No current article selected
+
+   Example of STAT by message-id on a server that sometimes reports the
+   actual article number:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] STAT
+      [S] 223 3000234 <45223423@example.com>
+      [C] STAT <45223423@example.com>
+      [S] 223 0 <45223423@example.com>
+      [C] STAT <45223423@example.com>
+      [S] 223 3000234 <45223423@example.com>
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] STAT <45223423@example.com>
+      [S] 223 0 <45223423@example.com>
+      [C] GROUP alt.crossposts
+      [S] 211 9999 111111 222222 alt.crossposts
+      [C] STAT <45223423@example.com>
+      [S] 223 123456 <45223423@example.com>
+      [C] STAT
+      [S] 223 111111 <23894720@example.com>
+
+   The first STAT command establishes the identity of an article in the
+   group.  The second and third show that the server may, but need not,
+   give the article number when the message-id is specified.  The fourth
+   STAT command shows that zero must be specified if the article isn't
+   in the currently selected newsgroup.  The fifth shows that the
+   number, if provided, must be that relating to the currently selected
+   newsgroup.  The last one shows that the current article number is
+   still not changed by the use of STAT with a message-id even if it
+   returns an article number.
+
+
+
+
+
+Feather                     Standards Track                    [Page 55]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+6.3.  Article Posting
+
+   Article posting is done in one of two ways: individual article
+   posting from news-reading clients using POST, and article transfer
+   from other news servers using IHAVE.
+
+6.3.1.  POST
+
+6.3.1.1.  Usage
+
+   Indicating capability: POST
+
+   This command MUST NOT be pipelined.
+
+   Syntax
+     POST
+
+   Responses
+
+   Initial responses
+     340    Send article to be posted
+     440    Posting not permitted
+
+   Subsequent responses
+     240    Article received OK
+     441    Posting failed
+
+6.3.1.2.  Description
+
+   If posting is allowed, a 340 response MUST be returned to indicate
+   that the article to be posted should be sent.  If posting is
+   prohibited for some installation-dependent reason, a 440 response
+   MUST be returned.
+
+   If posting is permitted, the article MUST be in the format specified
+   in Section 3.6 and MUST be sent by the client to the server as a
+   multi-line data block (see Section 3.1.1).  Thus a single dot (".")
+   on a line indicates the end of the text, and lines starting with a
+   dot in the original text have that dot doubled during transmission.
+
+   Following the presentation of the termination sequence by the client,
+   the server MUST return a response indicating success or failure of
+   the article transfer.  Note that response codes 340 and 440 are used
+   in direct response to the POST command while 240 and 441 are returned
+   after the article is sent.
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 56]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   A response of 240 SHOULD indicate that, barring unforeseen server
+   errors, the posted article will be made available on the server
+   and/or transferred to other servers, as appropriate, possibly
+   following further processing.  In other words, articles not wanted by
+   the server SHOULD be rejected with a 441 response, rather than being
+   accepted and then discarded silently.  However, the client SHOULD NOT
+   assume that the article has been successfully transferred unless it
+   receives an affirmative response from the server and SHOULD NOT
+   assume that it is being made available to other clients without
+   explicitly checking (for example, using the STAT command).
+
+   If the session is interrupted before the response is received, it is
+   possible that an affirmative response was sent but has been lost.
+   Therefore, in any subsequent session, the client SHOULD either check
+   whether the article was successfully posted before resending or
+   ensure that the server will allocate the same message-id to the new
+   attempt (see Appendix A.2).  The latter approach is preferred since
+   the article might not have been made available for reading yet (for
+   example, it may have to go through a moderation process).
+
+6.3.1.3.  Examples
+
+   Example of a successful posting:
+
+      [C] POST
+      [S] 340 Input article; end with <CR-LF>.<CR-LF>
+      [C] From: "Demo User" <nobody@example.net>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Organization: An Example Net
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [S] 240 Article received OK
+
+   Example of an unsuccessful posting:
+
+      [C] POST
+      [S] 340 Input article; end with <CR-LF>.<CR-LF>
+      [C] From: "Demo User" <nobody@example.net>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Organization: An Example Net
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [S] 441 Posting failed
+
+
+
+
+Feather                     Standards Track                    [Page 57]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of an attempt to post when posting is not allowed:
+
+      [Initial connection set-up completed.]
+      [S] 201 NNTP Service Ready, posting prohibited
+      [C] POST
+      [S] 440 Posting not permitted
+
+6.3.2.  IHAVE
+
+6.3.2.1.  Usage
+
+   Indicating capability: IHAVE
+
+   This command MUST NOT be pipelined.
+
+   Syntax
+     IHAVE message-id
+
+   Responses
+
+   Initial responses
+     335    Send article to be transferred
+     435    Article not wanted
+     436    Transfer not possible; try again later
+
+   Subsequent responses
+     235    Article transferred OK
+     436    Transfer failed; try again later
+     437    Transfer rejected; do not retry
+
+   Parameters
+     message-id    Article message-id
+
+6.3.2.2.  Description
+
+   The IHAVE command informs the server that the client has an article
+   with the specified message-id.  If the server desires a copy of that
+   article, a 335 response MUST be returned, instructing the client to
+   send the entire article.  If the server does not want the article
+   (if, for example, the server already has a copy of it), a 435
+   response MUST be returned, indicating that the article is not wanted.
+   Finally, if the article isn't wanted immediately but the client
+   should retry later if possible (if, for example, another client is in
+   the process of sending the same article to the server), a 436
+   response MUST be returned.
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 58]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   If transmission of the article is requested, the client MUST send the
+   entire article, including headers and body, to the server as a
+   multi-line data block (see Section 3.1.1).  Thus, a single dot (".")
+   on a line indicates the end of the text, and lines starting with a
+   dot in the original text have that dot doubled during transmission.
+   The server MUST return a 235 response, indicating that the article
+   was successfully transferred; a 436 response, indicating that the
+   transfer failed but should be tried again later; or a 437 response,
+   indicating that the article was rejected.
+
+   This function differs from the POST command in that it is intended
+   for use in transferring already-posted articles between hosts.  It
+   SHOULD NOT be used when the client is a personal news-reading
+   program, since use of this command indicates that the article has
+   already been posted at another site and is simply being forwarded
+   from another host.  However, despite this, the server MAY elect not
+   to post or forward the article if, after further examination of the
+   article, it deems it inappropriate to do so.  Reasons for such
+   subsequent rejection of an article may include problems such as
+   inappropriate newsgroups or distributions, disc space limitations,
+   article lengths, garbled headers, and the like.  These are typically
+   restrictions enforced by the server host's news software and not
+   necessarily by the NNTP server itself.
+
+   The client SHOULD NOT assume that the article has been successfully
+   transferred unless it receives an affirmative response from the
+   server.  A lack of response (such as a dropped network connection or
+   a network timeout) SHOULD be treated the same as a 436 response.
+
+   Because some news server software may not immediately be able to
+   determine whether an article is suitable for posting or forwarding,
+   an NNTP server MAY acknowledge the successful transfer of the article
+   (with a 235 response) but later silently discard it.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 59]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+6.3.2.3.  Examples
+
+   Example of successfully sending an article to another site:
+
+      [C] IHAVE <i.am.an.article.you.will.want@example.com>
+      [S] 335 Send it; end with <CR-LF>.<CR-LF>
+      [C] Path: pathost!demo!somewhere!not-for-mail
+      [C] From: "Demo User" <nobody@example.com>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Date: 6 Oct 1998 04:38:40 -0500
+      [C] Organization: An Example Com, San Jose, CA
+      [C] Message-ID: <i.am.an.article.you.will.want@example.com>
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [S] 235 Article transferred OK
+
+   Example of sending an article to another site that rejects it.  Note
+   that the message-id in the IHAVE command is not the same as the one
+   in the article headers; while this is bad practice and SHOULD NOT be
+   done, it is not forbidden.
+
+      [C] IHAVE <i.am.an.article.you.will.want@example.com>
+      [S] 335 Send it; end with <CR-LF>.<CR-LF>
+      [C] Path: pathost!demo!somewhere!not-for-mail
+      [C] From: "Demo User" <nobody@example.com>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Date: 6 Oct 1998 04:38:40 -0500
+      [C] Organization: An Example Com, San Jose, CA
+      [C] Message-ID: <i.am.an.article.you.have@example.com>
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [S] 437 Article rejected; don't send again
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 60]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of sending an article to another site where the transfer
+   fails:
+
+      [C] IHAVE <i.am.an.article.you.will.want@example.com>
+      [S] 335 Send it; end with <CR-LF>.<CR-LF>
+      [C] Path: pathost!demo!somewhere!not-for-mail
+      [C] From: "Demo User" <nobody@example.com>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Date: 6 Oct 1998 04:38:40 -0500
+      [C] Organization: An Example Com, San Jose, CA
+      [C] Message-ID: <i.am.an.article.you.will.want@example.com>
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [S] 436 Transfer failed
+
+   Example of sending an article to a site that already has it:
+
+      [C] IHAVE <i.am.an.article.you.have@example.com>
+      [S] 435 Duplicate
+
+   Example of sending an article to a site that requests that the
+   article be tried again later:
+
+      [C] IHAVE <i.am.an.article.you.defer@example.com>
+      [S] 436 Retry later
+
+7.  Information Commands
+
+   This section lists other commands that may be used at any time
+   between the beginning of a session and its termination.  Using these
+   commands does not alter any state information, but the response
+   generated from their use may provide useful information to clients.
+
+7.1.  DATE
+
+7.1.1.  Usage
+
+   Indicating capability: READER
+
+   Syntax
+     DATE
+
+   Responses
+     111 yyyymmddhhmmss    Server date and time
+
+
+
+
+
+Feather                     Standards Track                    [Page 61]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Parameters
+     yyyymmddhhmmss    Current UTC date and time on server
+
+7.1.2.  Description
+
+   This command exists to help clients find out the current Coordinated
+   Universal Time [TF.686-1] from the server's perspective.  This
+   command SHOULD NOT be used as a substitute for NTP [RFC1305] but to
+   provide information that might be useful when using the NEWNEWS
+   command (see Section 7.4).
+
+   The DATE command MUST return a timestamp from the same clock as is
+   used for determining article arrival and group creation times (see
+   Section 6).  This clock SHOULD be monotonic, and adjustments SHOULD
+   be made by running it fast or slow compared to "real" time rather
+   than by making sudden jumps.  A system providing NNTP service SHOULD
+   keep the system clock as accurate as possible, either with NTP or by
+   some other method.
+
+   The server MUST return a 111 response specifying the date and time on
+   the server in the form yyyymmddhhmmss.  This date and time is in
+   Coordinated Universal Time.
+
+7.1.3.  Examples
+
+      [C] DATE
+      [S] 111 19990623135624
+
+7.2.  HELP
+
+7.2.1.  Usage
+
+   This command is mandatory.
+
+   Syntax
+     HELP
+
+   Responses
+     100    Help text follows (multi-line)
+
+7.2.2.  Description
+
+   This command provides a short summary of the commands that are
+   understood by this implementation of the server.  The help text will
+   be presented as a multi-line data block following the 100 response
+   code.
+
+
+
+
+
+Feather                     Standards Track                    [Page 62]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   This text is not guaranteed to be in any particular format (but must
+   be UTF-8) and MUST NOT be used by clients as a replacement for the
+   CAPABILITIES command described in Section 5.2.
+
+7.2.3.  Examples
+
+      [C] HELP
+      [S] 100 Help text follows
+      [S] This is some help text.  There is no specific
+      [S] formatting requirement for this test, though
+      [S] it is customary for it to list the valid commands
+      [S] and give a brief definition of what they do.
+      [S] .
+
+7.3.  NEWGROUPS
+
+7.3.1.  Usage
+
+   Indicating capability: READER
+
+   Syntax
+     NEWGROUPS date time [GMT]
+
+   Responses
+     231    List of new newsgroups follows (multi-line)
+
+   Parameters
+     date    Date in yymmdd or yyyymmdd format
+     time    Time in hhmmss format
+
+7.3.2.  Description
+
+   This command returns a list of newsgroups created on the server since
+   the specified date and time.  The results are in the same format as
+   the LIST ACTIVE command (see Section 7.6.3).  However, they MAY
+   include groups not available on the server (and so not returned by
+   LIST ACTIVE) and MAY omit groups for which the creation date is not
+   available.
+
+   The date is specified as 6 or 8 digits in the format [xx]yymmdd,
+   where xx is the first two digits of the year (19-99), yy is the last
+   two digits of the year (00-99), mm is the month (01-12), and dd is
+   the day of the month (01-31).  Clients SHOULD specify all four digits
+   of the year.  If the first two digits of the year are not specified
+   (this is supported only for backward compatibility), the year is to
+   be taken from the current century if yy is smaller than or equal to
+   the current year, and the previous century otherwise.
+
+
+
+
+Feather                     Standards Track                    [Page 63]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   The time is specified as 6 digits in the format hhmmss, where hh is
+   the hours in the 24-hour clock (00-23), mm is the minutes (00-59),
+   and ss is the seconds (00-60, to allow for leap seconds).  The token
+   "GMT" specifies that the date and time are given in Coordinated
+   Universal Time [TF.686-1]; if it is omitted, then the date and time
+   are specified in the server's local timezone.  Note that there is no
+   way of using the protocol specified in this document to establish the
+   server's local timezone.
+
+   Note that an empty list is a possible valid response and indicates
+   that there are no new newsgroups since that date-time.
+
+   Clients SHOULD make all queries using Coordinated Universal Time
+   (i.e., by including the "GMT" argument) when possible.
+
+7.3.3.  Examples
+
+   Example where there are new groups:
+
+      [C] NEWGROUPS 19990624 000000 GMT
+      [S] 231 list of new newsgroups follows
+      [S] alt.rfc-writers.recovery 4 1 y
+      [S] tx.natives.recovery 89 56 y
+      [S] .
+
+   Example where there are no new groups:
+
+      [C] NEWGROUPS 19990624 000000 GMT
+      [S] 231 list of new newsgroups follows
+      [S] .
+
+7.4.  NEWNEWS
+
+7.4.1.  Usage
+
+   Indicating capability: NEWNEWS
+
+   Syntax
+     NEWNEWS wildmat date time [GMT]
+
+   Responses
+     230    List of new articles follows (multi-line)
+
+   Parameters
+     wildmat    Newsgroups of interest
+     date       Date in yymmdd or yyyymmdd format
+     time       Time in hhmmss format
+
+
+
+
+Feather                     Standards Track                    [Page 64]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+7.4.2.  Description
+
+   This command returns a list of message-ids of articles posted or
+   received on the server, in the newsgroups whose names match the
+   wildmat, since the specified date and time.  One message-id is sent
+   on each line; the order of the response has no specific significance
+   and may vary from response to response in the same session.  A
+   message-id MAY appear more than once; if it does, it has the same
+   meaning as if it appeared only once.
+
+   Date and time are in the same format as the NEWGROUPS command (see
+   Section 7.3).
+
+   Note that an empty list is a possible valid response and indicates
+   that there is currently no new news in the relevant groups.
+
+   Clients SHOULD make all queries in Coordinated Universal Time (i.e.,
+   by using the "GMT" argument) when possible.
+
+7.4.3.  Examples
+
+   Example where there are new articles:
+
+      [C] NEWNEWS news.*,sci.* 19990624 000000 GMT
+      [S] 230 list of new articles by message-id follows
+      [S] <i.am.a.new.article@example.com>
+      [S] <i.am.another.new.article@example.com>
+      [S] .
+
+   Example where there are no new articles:
+
+      [C] NEWNEWS alt.* 19990624 000000 GMT
+      [S] 230 list of new articles by message-id follows
+      [S] .
+
+7.5.  Time
+
+   As described in Section 6, each article has an arrival timestamp.
+   Each newsgroup also has a creation timestamp.  These timestamps are
+   used by the NEWNEWS and NEWGROUP commands to construct their
+   responses.
+
+   Clients can ensure that they do not have gaps in lists of articles or
+   groups by using the DATE command in the following manner:
+
+   First session:
+      Issue DATE command and record result.
+      Issue NEWNEWS command using a previously chosen timestamp.
+
+
+
+Feather                     Standards Track                    [Page 65]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Subsequent sessions:
+      Issue DATE command and hold result in temporary storage.
+      Issue NEWNEWS command using timestamp saved from previous session.
+      Overwrite saved timestamp with that currently in temporary
+      storage.
+
+   In order to allow for minor errors, clients MAY want to adjust the
+   timestamp back by two or three minutes before using it in NEWNEWS.
+
+7.5.1.  Examples
+
+   First session:
+
+      [C] DATE
+      [S] 111 20010203112233
+      [C] NEWNEWS local.chat 20001231 235959 GMT
+      [S] 230 list follows
+      [S] <article.1@local.service>
+      [S] <article.2@local.service>
+      [S] <article.3@local.service>
+      [S] .
+
+   Second session (the client has subtracted 3 minutes from the
+   timestamp returned previously):
+
+      [C] DATE
+      [S] 111 20010204003344
+      [C] NEWNEWS local.chat 20010203 111933 GMT
+      [S] 230 list follows
+      [S] <article.3@local.service>
+      [S] <article.4@local.service>
+      [S] <article.5@local.service>
+      [S] .
+
+   Note how <article.3@local.service> arrived in the 3 minute gap and so
+   is listed in both responses.
+
+7.6.  The LIST Commands
+
+   The LIST family of commands all return information that is multi-line
+   and that can, in general, be expected not to change during the
+   session.  Often the information is related to newsgroups, in which
+   case the response has one line per newsgroup and a wildmat MAY be
+   provided to restrict the groups for which information is returned.
+
+   The set of available keywords (including those provided by
+   extensions) is given in the capability list with capability label
+   LIST.
+
+
+
+Feather                     Standards Track                    [Page 66]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+7.6.1.  LIST
+
+7.6.1.1.  Usage
+
+   Indicating capability: LIST
+
+   Syntax
+     LIST [keyword [wildmat|argument]]
+
+   Responses
+     215    Information follows (multi-line)
+
+   Parameters
+     keyword     Information requested [1]
+     argument    Specific to keyword
+     wildmat     Groups of interest
+
+   [1] If no keyword is provided, it defaults to ACTIVE.
+
+7.6.1.2.  Description
+
+   The LIST command allows the server to provide blocks of information
+   to the client.  This information may be global or may be related to
+   newsgroups; in the latter case, the information may be returned
+   either for all groups or only for those matching a wildmat.  Each
+   block of information is represented by a different keyword.  The
+   command returns the specific information identified by the keyword.
+
+   If the information is available, it is returned as a multi-line data
+   block following the 215 response code.  The format of the information
+   depends on the keyword.  The information MAY be affected by the
+   additional argument, but the format MUST NOT be.
+
+   If the information is based on newsgroups and the optional wildmat
+   argument is specified, the response is limited to only the groups (if
+   any) whose names match the wildmat and for which the information is
+   available.
+
+   Note that an empty list is a possible valid response; for a
+   newsgroup-based keyword, it indicates that there are no groups
+   meeting the above criteria.
+
+   If the keyword is not recognised, or if an argument is specified and
+   the keyword does not expect one, a 501 response code MUST BE
+   returned.  If the keyword is recognised but the server does not
+   maintain the information, a 503 response code MUST BE returned.
+
+
+
+
+
+Feather                     Standards Track                    [Page 67]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   The LIST command MUST NOT change the visible state of the server in
+   any way; that is, the behaviour of subsequent commands MUST NOT be
+   affected by whether the LIST command was issued.  For example, it
+   MUST NOT make groups available that otherwise would not have been.
+
+7.6.1.3.  Examples
+
+   Example of LIST with the ACTIVE keyword:
+
+      [C] LIST ACTIVE
+      [S] 215 list of newsgroups follows
+      [S] misc.test 3002322 3000234 y
+      [S] comp.risks 442001 441099 m
+      [S] alt.rfc-writers.recovery 4 1 y
+      [S] tx.natives.recovery 89 56 y
+      [S] tx.natives.recovery.d 11 9 n
+      [S] .
+
+   Example of LIST with no keyword:
+
+      [C] LIST
+      [S] 215 list of newsgroups follows
+      [S] misc.test 3002322 3000234 y
+      [S] comp.risks 442001 441099 m
+      [S] alt.rfc-writers.recovery 4 1 y
+      [S] tx.natives.recovery 89 56 y
+      [S] tx.natives.recovery.d 11 9 n
+      [S] .
+
+   The output is identical to that of the previous example.
+
+   Example of LIST on a newsgroup-based keyword with and without
+   wildmat:
+
+      [C] LIST ACTIVE.TIMES
+      [S] 215 information follows
+      [S] misc.test 930445408 <creatme@isc.org>
+      [S] alt.rfc-writers.recovery 930562309 <m@example.com>
+      [S] tx.natives.recovery 930678923 <sob@academ.com>
+      [S] .
+      [C] LIST ACTIVE.TIMES tx.*
+      [S] 215 information follows
+      [S] tx.natives.recovery 930678923 <sob@academ.com>
+      [S] .
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 68]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of LIST returning an error where the keyword is recognized
+   but the software does not maintain this information:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] LIST ACTIVE NEWSGROUPS ACTIVE.TIMES XTRA.DATA
+      [S] .
+      [C] LIST XTRA.DATA
+      [S] 503 Data item not stored
+
+   Example of LIST where the keyword is not recognised:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] LIST ACTIVE NEWSGROUPS ACTIVE.TIMES XTRA.DATA
+      [S] .
+      [C] LIST DISTRIB.PATS
+      [S] 501 Syntax Error
+
+7.6.2.  Standard LIST Keywords
+
+   This specification defines the following LIST keywords:
+
+   +--------------+---------------+------------------------------------+
+   | Keyword      | Definition    | Status                             |
+   +--------------+---------------+------------------------------------+
+   | ACTIVE       | Section 7.6.3 | Mandatory if the READER capability |
+   |              |               | is advertised                      |
+   |              |               |                                    |
+   | ACTIVE.TIMES | Section 7.6.4 | Optional                           |
+   |              |               |                                    |
+   | DISTRIB.PATS | Section 7.6.5 | Optional                           |
+   |              |               |                                    |
+   | HEADERS      | Section 8.6   | Mandatory if the HDR capability is |
+   |              |               | advertised                         |
+   |              |               |                                    |
+   | NEWSGROUPS   | Section 7.6.6 | Mandatory if the READER capability |
+   |              |               | is advertised                      |
+   |              |               |                                    |
+   | OVERVIEW.FMT | Section 8.4   | Mandatory if the OVER capability   |
+   |              |               | is advertised                      |
+   +--------------+---------------+------------------------------------+
+
+
+
+
+
+Feather                     Standards Track                    [Page 69]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Where one of these LIST keywords is supported by a server, it MUST
+   have the meaning given in the relevant sub-section.
+
+7.6.3.  LIST ACTIVE
+
+   This keyword MUST be supported by servers advertising the READER
+   capability.
+
+   LIST ACTIVE returns a list of valid newsgroups and associated
+   information.  If no wildmat is specified, the server MUST include
+   every group that the client is permitted to select with the GROUP
+   command (Section 6.1.1).  Each line of this list consists of four
+   fields separated from each other by one or more spaces:
+
+   o  The name of the newsgroup.
+   o  The reported high water mark for the group.
+   o  The reported low water mark for the group.
+   o  The current status of the group on this server.
+
+   The reported high and low water marks are as described in the GROUP
+   command (see Section 6.1.1), but note that they are in the opposite
+   order to the 211 response to that command.
+
+   The status field is typically one of the following:
+
+   "y" Posting is permitted.
+
+   "n" Posting is not permitted.
+
+   "m" Postings will be forwarded to the newsgroup moderator.
+
+   The server SHOULD use these values when these meanings are required
+   and MUST NOT use them with any other meaning.  Other values for the
+   status may exist; the definition of these other values and the
+   circumstances under which they are returned may be specified in an
+   extension or may be private to the server.  A client SHOULD treat an
+   unrecognized status as giving no information.
+
+   The status of a newsgroup only indicates how posts to that newsgroup
+   are normally processed and is not necessarily customised to the
+   specific client.  For example, if the current client is forbidden
+   from posting, then this will apply equally to groups with status "y".
+   Conversely, a client with special privileges (not defined by this
+   specification) might be able to post to a group with status "n".
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 70]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   For example:
+
+      [C] LIST ACTIVE
+      [S] 215 list of newsgroups follows
+      [S] misc.test 3002322 3000234 y
+      [S] comp.risks 442001 441099 m
+      [S] alt.rfc-writers.recovery 4 1 y
+      [S] tx.natives.recovery 89 56 y
+      [S] tx.natives.recovery.d 11 9 n
+      [S] .
+
+   or, on an implementation that includes leading zeroes:
+
+      [C] LIST ACTIVE
+      [S] 215 list of newsgroups follows
+      [S] misc.test 0003002322 0003000234 y
+      [S] comp.risks 0000442001 0000441099 m
+      [S] alt.rfc-writers.recovery 0000000004 0000000001 y
+      [S] tx.natives.recovery 0000000089 0000000056 y
+      [S] tx.natives.recovery.d 0000000011 0000000009 n
+      [S] .
+
+   The information is newsgroup based, and a wildmat MAY be specified,
+   in which case the response is limited to only the groups (if any)
+   whose names match the wildmat.  For example:
+
+      [C] LIST ACTIVE *.recovery
+      [S] 215 list of newsgroups follows
+      [S] alt.rfc-writers.recovery 4 1 y
+      [S] tx.natives.recovery 89 56 y
+      [S] .
+
+7.6.4.  LIST ACTIVE.TIMES
+
+   This keyword is optional.
+
+   The active.times list is maintained by some NNTP servers to contain
+   information about who created a particular newsgroup and when.  Each
+   line of this list consists of three fields separated from each other
+   by one or more spaces.  The first field is the name of the newsgroup.
+   The second is the time when this group was created on this news
+   server, measured in seconds since the start of January 1, 1970.  The
+   third is plain text intended to describe the entity that created the
+   newsgroup; it is often a mailbox as defined in RFC 2822 [RFC2822].
+   For example:
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 71]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+      [C] LIST ACTIVE.TIMES
+      [S] 215 information follows
+      [S] misc.test 930445408 <creatme@isc.org>
+      [S] alt.rfc-writers.recovery 930562309 <m@example.com>
+      [S] tx.natives.recovery 930678923 <sob@academ.com>
+      [S] .
+
+   The list MAY omit newsgroups for which the information is unavailable
+   and MAY include groups not available on the server; in particular, it
+   MAY omit all groups created before the date and time of the oldest
+   entry.  The client MUST NOT assume that the list is complete or that
+   it matches the list returned by the LIST ACTIVE command
+   (Section 7.6.3).  The NEWGROUPS command (Section 7.3) may provide a
+   better way to access this information, and the results of the two
+   commands SHOULD be consistent except that, if the latter is invoked
+   with a date and time earlier than the oldest entry in active.times
+   list, its result may include extra groups.
+
+   The information is newsgroup based, and a wildmat MAY be specified,
+   in which case the response is limited to only the groups (if any)
+   whose names match the wildmat.
+
+7.6.5.  LIST DISTRIB.PATS
+
+   This keyword is optional.
+
+   The distrib.pats list is maintained by some NNTP servers to assist
+   clients to choose a value for the content of the Distribution header
+   of a news article being posted.  Each line of this list consists of
+   three fields separated from each other by a colon (":").  The first
+   field is a weight, the second field is a wildmat (which may be a
+   simple newsgroup name), and the third field is a value for the
+   Distribution header content.  For example:
+
+      [C] LIST DISTRIB.PATS
+      [S] 215 information follows
+      [S] 10:local.*:local
+      [S] 5:*:world
+      [S] 20:local.here.*:thissite
+      [S] .
+
+   The client MAY use this information to construct an appropriate
+   Distribution header given the name of a newsgroup.  To do so, it
+   should determine the lines whose second field matches the newsgroup
+   name, select from among them the line with the highest weight (with 0
+   being the lowest), and use the value of the third field to construct
+   the Distribution header.
+
+
+
+
+Feather                     Standards Track                    [Page 72]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   The information is not newsgroup based, and an argument MUST NOT be
+   specified.
+
+7.6.6.  LIST NEWSGROUPS
+
+   This keyword MUST be supported by servers advertising the READER
+   capability.
+
+   The newsgroups list is maintained by NNTP servers to contain the name
+   of each newsgroup that is available on the server and a short
+   description about the purpose of the group.  Each line of this list
+   consists of two fields separated from each other by one or more space
+   or TAB characters (the usual practice is a single TAB).  The first
+   field is the name of the newsgroup, and the second is a short
+   description of the group.  For example:
+
+      [C] LIST NEWSGROUPS
+      [S] 215 information follows
+      [S] misc.test General Usenet testing
+      [S] alt.rfc-writers.recovery RFC Writers Recovery
+      [S] tx.natives.recovery Texas Natives Recovery
+      [S] .
+
+   The list MAY omit newsgroups for which the information is unavailable
+   and MAY include groups not available on the server.  The client MUST
+   NOT assume that the list is complete or that it matches the list
+   returned by LIST ACTIVE.
+
+   The description SHOULD be in UTF-8.  However, servers often obtain
+   the information from external sources.  These sources may have used
+   different encodings (ones that use octets in the range 128 to 255 in
+   some other manner) and, in that case, the server MAY pass it on
+   unchanged.  Therefore, clients MUST be prepared to receive such
+   descriptions.
+
+   The information is newsgroup based, and a wildmat MAY be specified,
+   in which case the response is limited to only the groups (if any)
+   whose names match the wildmat.
+
+8.  Article Field Access Commands
+
+   This section lists commands that may be used to access specific
+   article fields; that is, headers of articles and metadata about
+   articles.  These commands typically fetch data from an "overview
+   database", which is a database of headers extracted from incoming
+   articles plus metadata determined as the article arrives.  Only
+   certain fields are included in the database.
+
+
+
+
+Feather                     Standards Track                    [Page 73]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   This section is based on the Overview/NOV database [ROBE1995]
+   developed by Geoff Collyer.
+
+8.1.  Article Metadata
+
+   Article "metadata" is data about articles that does not occur within
+   the article itself.  Each metadata item has a name that MUST begin
+   with a colon (and that MUST NOT contain a colon elsewhere within it).
+   As with header names, metadata item names are not case sensitive.
+
+   When generating a metadata item, the server MUST compute it for
+   itself and MUST NOT trust any related value provided in the article.
+   (In particular, a Lines or Bytes header in the article MUST NOT be
+   assumed to specify the correct number of lines or bytes in the
+   article.)  If the server has access to several non-identical copies
+   of an article, the value returned MUST be correct for any copy of
+   that article retrieved during the same session.
+
+   This specification defines two metadata items: ":bytes" and ":lines".
+   Other metadata items may be defined by extensions.  The names of
+   metadata items defined by registered extensions MUST NOT begin with
+   ":x-".  To avoid the risk of a clash with a future registered
+   extension, the names of metadata items defined by private extensions
+   SHOULD begin with ":x-".
+
+8.1.1.  The :bytes Metadata Item
+
+   The :bytes metadata item for an article is a decimal integer.  It
+   SHOULD equal the number of octets in the entire article: headers,
+   body, and separating empty line (counting a CRLF pair as two octets,
+   and excluding both the "." CRLF terminating the response and any "."
+   added for "dot-stuffing" purposes).
+
+   Note to client implementers: some existing servers return a value
+   different from that above.  The commonest reasons for this are as
+   follows:
+
+   o  Counting a CRLF pair as one octet.
+
+   o  Including the "." character used for dot-stuffing in the number.
+
+   o  Including the terminating "." CRLF in the number.
+
+   o  Using one copy of an article for counting the octets but then
+      returning another one that differs in some (permitted) manner.
+
+   Implementations should be prepared for such variation and MUST NOT
+   rely on the value being accurate.
+
+
+
+Feather                     Standards Track                    [Page 74]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+8.1.2.  The :lines Metadata Item
+
+   The :lines metadata item for an article is a decimal integer.  It
+   MUST equal the number of lines in the article body (excluding the
+   empty line separating headers and body).  Equivalently, it is two
+   less than the number of CRLF pairs that the BODY command would return
+   for that article (the extra two are those following the response code
+   and the termination octet).
+
+8.2.  Database Consistency
+
+   The information stored in the overview database may change over time.
+   If the database records the content or absence of a given field (that
+   is, a header or metadata item) for all articles, it is said to be
+   "consistent" for that field.  If it records the content of a header
+   for some articles but not for others that nevertheless included that
+   header, or if it records a metadata item for some articles but not
+   for others to which that item applies, it is said to be
+   "inconsistent" for that field.
+
+   The LIST OVERVIEW.FMT command SHOULD list all the fields for which
+   the database is consistent at that moment.  It MAY omit such fields
+   (for example, if it is not known whether the database is consistent
+   or inconsistent).  It MUST NOT include fields for which the database
+   is inconsistent or that are not stored in the database.  Therefore,
+   if a header appears in the LIST OVERVIEW.FMT output but not in the
+   OVER output for a given article, that header does not appear in the
+   article (similarly for metadata items).
+
+   These rules assume that the fields being stored in the database
+   remain constant for long periods of time, and therefore the database
+   will be consistent.  When the set of fields to be stored is changed,
+   it will be inconsistent until either the database is rebuilt or the
+   only articles remaining are those received since the change.
+   Therefore, the output from LIST OVERVIEW.FMT needs to be altered
+   twice.  Firstly, before any fields stop being stored they MUST be
+   removed from the output; then, when the database is once more known
+   to be consistent, the new fields SHOULD be added to the output.
+
+   If the HDR command uses the overview database rather than taking
+   information directly from the articles, the same issues of
+   consistency and inconsistency apply, and the LIST HEADERS command
+   SHOULD take the same approach as the LIST OVERVIEW.FMT command in
+   resolving them.
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 75]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+8.3.  OVER
+
+8.3.1.  Usage
+
+   Indicating capability: OVER
+
+   Syntax
+     OVER message-id
+     OVER range
+     OVER
+
+   Responses
+
+   First form (message-id specified)
+     224    Overview information follows (multi-line)
+     430    No article with that message-id
+
+   Second form (range specified)
+     224    Overview information follows (multi-line)
+     412    No newsgroup selected
+     423    No articles in that range
+
+   Third form (current article number used)
+     224    Overview information follows (multi-line)
+     412    No newsgroup selected
+     420    Current article number is invalid
+
+   Parameters
+     range         Number(s) of articles
+     message-id    Message-id of article
+
+8.3.2.  Description
+
+   The OVER command returns the contents of all the fields in the
+   database for an article specified by message-id, or from a specified
+   article or range of articles in the currently selected newsgroup.
+
+   The message-id argument indicates a specific article.  The range
+   argument may be any of the following:
+
+   o  An article number.
+
+   o  An article number followed by a dash to indicate all following.
+
+   o  An article number followed by a dash followed by another article
+      number.
+
+   If neither is specified, the current article number is used.
+
+
+
+Feather                     Standards Track                    [Page 76]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Support for the first (message-id) form is optional.  If it is
+   supported, the OVER capability line MUST include the argument
+   "MSGID".  Otherwise, the capability line MUST NOT include this
+   argument, and the OVER command MUST return the generic response code
+   503 when this form is used.
+
+   If the information is available, it is returned as a multi-line data
+   block following the 224 response code and contains one line per
+   article, sorted in numerical order of article number.  (Note that
+   unless the argument is a range including a dash, there will be
+   exactly one line in the data block.)  Each line consists of a number
+   of fields separated by a TAB.  A field may be empty (in which case
+   there will be two adjacent TABs), and a sequence of trailing TABs may
+   be omitted.
+
+   The first 8 fields MUST be the following, in order:
+
+      "0" or article number (see below)
+      Subject header content
+      From header content
+      Date header content
+      Message-ID header content
+      References header content
+      :bytes metadata item
+      :lines metadata item
+
+   If the article is specified by message-id (the first form of the
+   command), the article number MUST be replaced with zero, except that
+   if there is a currently selected newsgroup and the article is present
+   in that group, the server MAY use the article's number in that group.
+   (See the ARTICLE command (Section 6.2.1) and STAT examples
+   (Section 6.2.4.3) for more details.)  In the other two forms of the
+   command, the article number MUST be returned.
+
+   Any subsequent fields are the contents of the other headers and
+   metadata held in the database.
+
+   For the five mandatory headers, the content of each field MUST be
+   based on the content of the header (that is, with the header name and
+   following colon and space removed).  If the article does not contain
+   that header, or if the content is empty, the field MUST be empty.
+   For the two mandatory metadata items, the content of the field MUST
+   be just the value, with no other text.
+
+   For all subsequent fields that contain headers, the content MUST be
+   the entire header line other than the trailing CRLF.  For all
+   subsequent fields that contain metadata, the field consists of the
+   metadata name, a single space, and then the value.
+
+
+
+Feather                     Standards Track                    [Page 77]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   For all fields, the value is processed by first removing all CRLF
+   pairs (that is, undoing any folding and removing the terminating
+   CRLF) and then replacing each TAB with a single space.  If there is
+   no such header in the article, no such metadata item, or no header or
+   item stored in the database for that article, the corresponding field
+   MUST be empty.
+
+   Note that, after unfolding, the characters NUL, LF, and CR cannot
+   occur in the header of an article offered by a conformant server.
+   Nevertheless, servers SHOULD check for these characters and replace
+   each one by a single space (so that, for example, CR LF LF TAB will
+   become two spaces, since the CR and first LF will be removed by the
+   unfolding process).  This will encourage robustness in the face of
+   non-conforming data; it is also possible that future versions of this
+   specification could permit these characters to appear in articles.
+
+   The server SHOULD NOT produce output for articles that no longer
+   exist.
+
+   If the argument is a message-id and no such article exists, a 430
+   response MUST be returned.  If the argument is a range or is omitted
+   and the currently selected newsgroup is invalid, a 412 response MUST
+   be returned.  If the argument is a range and no articles in that
+   number range exist in the currently selected newsgroup, including the
+   case where the second number is less than the first one, a 423
+   response MUST be returned.  If the argument is omitted and the
+   current article number is invalid, a 420 response MUST be returned.
+
+8.3.3.  Examples
+
+   In the first four examples, TAB has been replaced by vertical bar and
+   some lines have been folded for readability.
+
+   Example of a successful retrieval of overview information for an
+   article (explicitly not using an article number):
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] OVER
+      [S] 224 Overview information follows
+      [S] 3000234|I am just a test article|"Demo User"
+          <nobody@example.com>|6 Oct 1998 04:38:40 -0500|
+          <45223423@example.com>|<45454@example.net>|1234|
+          17|Xref: news.example.com misc.test:3000363
+      [S] .
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 78]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of a successful retrieval of overview information for an
+   article by message-id:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] OVER MSGID
+      [S] LIST ACTIVE NEWSGROUPS OVERVIEW.FMT
+      [S] .
+      [C] OVER <45223423@example.com>
+      [S] 224 Overview information follows
+      [S] 0|I am just a test article|"Demo User"
+          <nobody@example.com>|6 Oct 1998 04:38:40 -0500|
+          <45223423@example.com>|<45454@example.net>|1234|
+          17|Xref: news.example.com misc.test:3000363
+      [S] .
+
+   Note that the article number has been replaced by "0".
+
+   Example of the same commands on a system that does not implement
+   retrieval by message-id:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] OVER
+      [S] LIST ACTIVE NEWSGROUPS OVERVIEW.FMT
+      [S] .
+      [C] OVER <45223423@example.com>
+      [S] 503 Overview by message-id unsupported
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 79]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of a successful retrieval of overview information for a range
+   of articles:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] OVER 3000234-3000240
+      [S] 224 Overview information follows
+      [S] 3000234|I am just a test article|"Demo User"
+          <nobody@example.com>|6 Oct 1998 04:38:40 -0500|
+          <45223423@example.com>|<45454@example.net>|1234|
+          17|Xref: news.example.com misc.test:3000363
+      [S] 3000235|Another test article|nobody@nowhere.to
+          (Demo User)|6 Oct 1998 04:38:45 -0500|<45223425@to.to>||
+          4818|37||Distribution: fi
+      [S] 3000238|Re: I am just a test article|somebody@elsewhere.to|
+          7 Oct 1998 11:38:40 +1200|<kfwer3v@elsewhere.to>|
+          <45223423@to.to>|9234|51
+      [S] .
+
+   Note the missing "References" and Xref headers in the second line,
+   the missing trailing fields in the first and last lines, and that
+   there are only results for those articles that still exist.
+
+   Example of an unsuccessful retrieval of overview information on an
+   article by number:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] OVER 300256
+      [S] 423 No such article in this group
+
+   Example of an invalid range:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] OVER 3000444-3000222
+      [S] 423 Empty range
+
+   Example of an unsuccessful retrieval of overview information by
+   number because no newsgroup was selected first:
+
+      [Assumes currently selected newsgroup is invalid.]
+      [C] OVER
+      [S] 412 No newsgroup selected
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 80]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of an attempt to retrieve information when the currently
+   selected newsgroup is empty:
+
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] OVER
+      [S] 420 No current article selected
+
+8.4.  LIST OVERVIEW.FMT
+
+8.4.1.  Usage
+
+   Indicating capability: OVER
+
+   Syntax
+     LIST OVERVIEW.FMT
+
+   Responses
+     215    Information follows (multi-line)
+
+8.4.2.  Description
+
+   See Section 7.6.1 for general requirements of the LIST command.
+
+   The LIST OVERVIEW.FMT command returns a description of the fields in
+   the database for which it is consistent (as described above).  The
+   information is returned as a multi-line data block following the 215
+   response code.  The information contains one line per field in the
+   order in which they are returned by the OVER command; the first 7
+   lines MUST (except for the case of letters) be exactly as follows:
+
+       Subject:
+       From:
+       Date:
+       Message-ID:
+       References:
+       :bytes
+       :lines
+
+   For compatibility with existing implementations, the last two lines
+   MAY instead be:
+
+       Bytes:
+       Lines:
+
+   even though they refer to metadata, not headers.
+
+
+
+
+
+Feather                     Standards Track                    [Page 81]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   All subsequent lines MUST consist of either a header name followed by
+   ":full", or the name of a piece of metadata.
+
+   There are no leading or trailing spaces in the output.
+
+   Note that the 7 fixed lines describe the 2nd to 8th fields of the
+   OVER output.  The "full" suffix (which may use either uppercase,
+   lowercase, or a mix) is a reminder that the corresponding fields
+   include the header name.
+
+   This command MAY generate different results if it is used more than
+   once in a session.
+
+   If the OVER command is not implemented, the meaning of the output
+   from this command is not specified, but it must still meet the above
+   syntactic requirements.
+
+8.4.3.  Examples
+
+   Example of LIST OVERVIEW.FMT output corresponding to the example OVER
+   output above, in the preferred format:
+
+      [C] LIST OVERVIEW.FMT
+      [S] 215 Order of fields in overview database.
+      [S] Subject:
+      [S] From:
+      [S] Date:
+      [S] Message-ID:
+      [S] References:
+      [S] :bytes
+      [S] :lines
+      [S] Xref:full
+      [S] Distribution:full
+      [S] .
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 82]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of LIST OVERVIEW.FMT output corresponding to the example OVER
+   output above, in the alternative format:
+
+      [C] LIST OVERVIEW.FMT
+      [S] 215 Order of fields in overview database.
+      [S] Subject:
+      [S] From:
+      [S] Date:
+      [S] Message-ID:
+      [S] References:
+      [S] Bytes:
+      [S] Lines:
+      [S] Xref:FULL
+      [S] Distribution:FULL
+      [S] .
+
+8.5.  HDR
+
+8.5.1.  Usage
+
+   Indicating capability: HDR
+
+   Syntax
+     HDR field message-id
+     HDR field range
+     HDR field
+
+   Responses
+
+   First form (message-id specified)
+     225    Headers follow (multi-line)
+     430    No article with that message-id
+
+   Second form (range specified)
+     225    Headers follow (multi-line)
+     412    No newsgroup selected
+     423    No articles in that range
+
+   Third form (current article number used)
+     225    Headers follow (multi-line)
+     412    No newsgroup selected
+     420    Current article number is invalid
+
+   Parameters
+     field         Name of field
+     range         Number(s) of articles
+     message-id    Message-id of article
+
+
+
+
+Feather                     Standards Track                    [Page 83]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+8.5.2.  Description
+
+   The HDR command provides access to specific fields from an article
+   specified by message-id, or from a specified article or range of
+   articles in the currently selected newsgroup.  It MAY take the
+   information directly from the articles or from the overview database.
+   In the case of headers, an implementation MAY restrict the use of
+   this command to a specific list of headers or MAY allow it to be used
+   with any header; it may behave differently when it is used with a
+   message-id argument and when it is used with a range or no argument.
+
+   The required field argument is the name of a header with the colon
+   omitted (e.g., "subject") or the name of a metadata item including
+   the leading colon (e.g., ":bytes"), and is case insensitive.
+
+   The message-id argument indicates a specific article.  The range
+   argument may be any of the following:
+
+   o  An article number.
+
+   o  An article number followed by a dash to indicate all following.
+
+   o  An article number followed by a dash followed by another article
+      number.
+
+   If neither is specified, the current article number is used.
+
+   If the information is available, it is returned as a multi-line data
+   block following the 225 response code and contains one line for each
+   article in the range that exists.  (Note that unless the argument is
+   a range including a dash, there will be exactly one line in the data
+   block.)  The line consists of the article number, a space, and then
+   the contents of the field.  In the case of a header, the header name,
+   the colon, and the first space after the colon are all omitted.
+
+   If the article is specified by message-id (the first form of the
+   command), the article number MUST be replaced with zero, except that
+   if there is a currently selected newsgroup and the article is present
+   in that group, the server MAY use the article's number in that group.
+   (See the ARTICLE command (Section 6.2.1) and STAT examples
+   (Section 6.2.4.3) for more details.)  In the other two forms of the
+   command, the article number MUST be returned.
+
+   Header contents are modified as follows: all CRLF pairs are removed,
+   and then each TAB is replaced with a single space.  (Note that this
+   is the same transformation as is performed by the OVER command
+   (Section 8.3.2), and the same comment concerning NUL, CR, and LF
+   applies.)
+
+
+
+Feather                     Standards Track                    [Page 84]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Note the distinction between headers and metadata appearing to have
+   the same meaning.  Headers are always taken unchanged from the
+   article; metadata are always calculated.  For example, a request for
+   "Lines" returns the contents of the "Lines" header of the specified
+   articles, if any, no matter whether they accurately state the number
+   of lines, while a request for ":lines" returns the line count
+   metadata, which is always the actual number of lines irrespective of
+   what any header may state.
+
+   If the requested header is not present in the article, or if it is
+   present but empty, a line for that article is included in the output,
+   but the header content portion of the line is empty (the space after
+   the article number MAY be retained or omitted).  If the header occurs
+   in a given article more than once, only the content of the first
+   occurrence is returned by HDR.  If any article number in the provided
+   range does not exist in the group, no line for that article number is
+   included in the output.
+
+   If the second argument is a message-id and no such article exists, a
+   430 response MUST be returned.  If the second argument is a range or
+   is omitted and the currently selected newsgroup is invalid, a 412
+   response MUST be returned.  If the second argument is a range and no
+   articles in that number range exist in the currently selected
+   newsgroup, including the case where the second number is less than
+   the first one, a 423 response MUST be returned.  If the second
+   argument is omitted and the current article number is invalid, a 420
+   response MUST be returned.
+
+   A server MAY only allow HDR commands for a limited set of fields; it
+   may behave differently in this respect for the first (message-id)
+   form from how it would for the other forms.  If so, it MUST respond
+   with the generic 503 response to attempts to request other fields,
+   rather than return erroneous results, such as a successful empty
+   response.
+
+   If HDR uses the overview database and it is inconsistent for the
+   requested field, the server MAY return what results it can, or it MAY
+   respond with the generic 503 response.  In the latter case, the field
+   MUST NOT appear in the output from LIST HEADERS.
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 85]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+8.5.3.  Examples
+
+   Example of a successful retrieval of subject lines from a range of
+   articles (3000235 has no Subject header, and 3000236 is missing):
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] HDR Subject 3000234-3000238
+      [S] 225 Headers follow
+      [S] 3000234 I am just a test article
+      [S] 3000235
+      [S] 3000237 Re: I am just a test article
+      [S] 3000238 Ditto
+      [S] .
+
+   Example of a successful retrieval of line counts from a range of
+   articles:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] HDR :lines 3000234-3000238
+      [S] 225 Headers follow
+      [S] 3000234 42
+      [S] 3000235 5
+      [S] 3000237 11
+      [S] 3000238 2378
+      [S] .
+
+   Example of a successful retrieval of the subject line from an article
+   by message-id:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] HDR subject <i.am.a.test.article@example.com>
+      [S] 225 Header information follows
+      [S] 0 I am just a test article
+      [S] .
+
+   Example of a successful retrieval of the subject line from the
+   current article:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] HDR subject
+      [S] 225 Header information follows
+      [S] 3000234 I am just a test article
+      [S] .
+
+
+
+
+Feather                     Standards Track                    [Page 86]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of an unsuccessful retrieval of a header from an article by
+   message-id:
+
+      [C] HDR subject <i.am.not.there@example.com>
+      [S] 430 No Such Article Found
+
+   Example of an unsuccessful retrieval of headers from articles by
+   number because no newsgroup was selected first:
+
+      [Assumes currently selected newsgroup is invalid.]
+      [C] HDR subject 300256-
+      [S] 412 No newsgroup selected
+
+   Example of an unsuccessful retrieval of headers because the currently
+   selected newsgroup is empty:
+
+      [C] GROUP example.empty.newsgroup
+      [S] 211 0 0 0 example.empty.newsgroup
+      [C] HDR subject 1-
+      [S] 423 No articles in that range
+
+   Example of an unsuccessful retrieval of headers because the server
+   does not allow HDR commands for that header:
+
+      [C] GROUP misc.test
+      [S] 211 1234 3000234 3002322 misc.test
+      [C] HDR Content-Type 3000234-3000238
+      [S] 503 HDR not permitted on Content-Type
+
+8.6.  LIST HEADERS
+
+8.6.1.  Usage
+
+   Indicating capability: HDR
+
+   Syntax
+     LIST HEADERS [MSGID|RANGE]
+
+   Responses
+     215    Field list follows (multi-line)
+
+   Parameters
+     MSGID    Requests list for access by message-id
+     RANGE    Requests list for access by range
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 87]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+8.6.2.  Description
+
+   See Section 7.6.1 for general requirements of the LIST command.
+
+   The LIST HEADERS command returns a list of fields that may be
+   retrieved using the HDR command.
+
+   The information is returned as a multi-line data block following the
+   215 response code and contains one line for each field name
+   (excluding the trailing colon for headers and including the leading
+   colon for metadata items).  If the implementation allows any header
+   to be retrieved, it MUST NOT include any header names in the list but
+   MUST include the special entry ":" (a single colon on its own).  It
+   MUST still explicitly list any metadata items that are available.
+   The order of items in the list is not significant; the server need
+   not even consistently return the same order.  The list MAY be empty
+   (though in this circumstance there is little point in providing the
+   HDR command).
+
+   An implementation that also supports the OVER command SHOULD at least
+   permit all the headers and metadata items listed in the output from
+   the LIST OVERVIEW.FMT command.
+
+   If the server treats the first form of the HDR command (message-id
+   specified) differently from the other two forms (range specified or
+   current article number used) in respect of which headers or metadata
+   items are available, then the following apply:
+
+   o  If the MSGID argument is specified, the results MUST be those
+      available for the first form of the HDR command.
+
+   o  If the RANGE argument is specified, the results MUST be those
+      available for the second and third forms of the HDR command.
+
+   o  If no argument is specified, the results MUST be those available
+      in all forms of the HDR command (that is, it MUST only list those
+      items listed in both the previous cases).
+
+   If the server does not treat the various forms differently, then it
+   MUST ignore any argument and always produce the same results (though
+   not necessarily always in the same order).
+
+   If the HDR command is not implemented, the meaning of the output from
+   this command is not specified, but it must still meet the above
+   syntactic requirements.
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 88]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+8.6.3.  Examples
+
+   Example of an implementation providing access to only a few headers:
+
+      [C] LIST HEADERS
+      [S] 215 headers supported:
+      [S] Subject
+      [S] Message-ID
+      [S] Xref
+      [S] .
+
+   Example of an implementation providing access to the same fields as
+   the first example in Section 8.4.3:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] OVER
+      [S] HDR
+      [S] LIST ACTIVE NEWSGROUPS HEADERS OVERVIEW.FMT
+      [S] .
+      [C] LIST HEADERS
+      [S] 215 headers and metadata items supported:
+      [S] Date
+      [S] Distribution
+      [S] From
+      [S] Message-ID
+      [S] References
+      [S] Subject
+      [S] Xref
+      [S] :bytes
+      [S] :lines
+      [S] .
+
+   Example of an implementation providing access to all headers:
+
+      [C] LIST HEADERS
+      [S] 215 metadata items supported:
+      [S] :
+      [S] :lines
+      [S] :bytes
+      [S] :x-article-number
+      [S] .
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 89]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Example of an implementation distinguishing the first form of the HDR
+   command from the other two forms:
+
+      [C] LIST HEADERS RANGE
+      [S] 215 metadata items supported:
+      [S] :
+      [S] :lines
+      [S] :bytes
+      [S] .
+      [C] LIST HEADERS MSGID
+      [S] 215 headers and metadata items supported:
+      [S] Date
+      [S] Distribution
+      [S] From
+      [S] Message-ID
+      [S] References
+      [S] Subject
+      [S] :lines
+      [S] :bytes
+      [S] :x-article-number
+      [S] .
+      [C] LIST HEADERS
+      [S] 215 headers and metadata items supported:
+      [S] Date
+      [S] Distribution
+      [S] From
+      [S] Message-ID
+      [S] References
+      [S] Subject
+      [S] :lines
+      [S] :bytes
+      [S] .
+
+   Note that :x-article-number does not appear in the last set of
+   output.
+
+9.  Augmented BNF Syntax for NNTP
+
+9.1.  Introduction
+
+   Each of the following sections describes the syntax of a major
+   element of NNTP.  This syntax extends and refines the descriptions
+   elsewhere in this specification and should be given precedence when
+   resolving apparent conflicts.  Note that ABNF [RFC4234] strings are
+   case insensitive.  Non-terminals used in several places are defined
+   in a separate section at the end.
+
+
+
+
+
+Feather                     Standards Track                    [Page 90]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Between them, the non-terminals <command-line>, <command-datastream>,
+   <command-continuation>, and <response> specify the text that flows
+   between client and server.  A consistent naming scheme is used in
+   this document for the non-terminals relating to each command, and
+   SHOULD be used by the specification of registered extensions.
+
+   For each command, the sequence is as follows:
+
+   o  The client sends an instance of <command-line>; the syntax for the
+      EXAMPLE command is <example-command>.
+
+   o  If the client is one that immediately streams data, it sends an
+      instance of <command-datastream>; the syntax for the EXAMPLE
+      command is <example-datastream>.
+
+   o  The server sends an instance of <response>.
+
+      *  The initial response line is independent of the command that
+         generated it; if the 000 response has arguments, the syntax of
+         the initial line is <response-000-content>.
+
+      *  If the response is multi-line, the initial line is followed by
+         a <multi-line-data-block>.  The syntax for the contents of this
+         block after "dot-stuffing" has been removed is (for the 000
+         response to the EXAMPLE command) <example-000-ml-content> and
+         is an instance of <multi-line-response-content>.
+
+   o  While the latest response is one that indicates more data is
+      required (in general, a 3xx response):
+
+      *  the client sends an instance of <command-continuation>; the
+         syntax for the EXAMPLE continuation following a 333 response is
+         <example-333-continuation>;
+
+      *  the server sends another instance of <response>, as above.
+
+   (There are no commands in this specification that immediately stream
+   data, but this non-terminal is defined for the convenience of
+   extensions.)
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                    [Page 91]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+9.2.  Commands
+
+   This syntax defines the non-terminal <command-line>, which represents
+   what is sent from the client to the server (see section 3.1 for
+   limits on lengths).
+
+     command-line = command EOL
+     command = X-command
+     X-command = keyword *(WS token)
+
+     command =/ article-command /
+           body-command /
+           capabilities-command /
+           date-command /
+           group-command /
+           hdr-command /
+           head-command /
+           help-command /
+           ihave-command /
+           last-command /
+           list-command /
+           listgroup-command /
+           mode-reader-command /
+           newgroups-command /
+           newnews-command /
+           next-command /
+           over-command /
+           post-command /
+           quit-command /
+           stat-command
+
+     article-command = "ARTICLE" [WS article-ref]
+     body-command = "BODY" [WS article-ref]
+     capabilities-command = "CAPABILITIES" [WS keyword]
+     date-command = "DATE"
+     group-command = "GROUP" [WS newsgroup-name]
+     hdr-command = "HDR" WS header-meta-name [WS range-ref]
+     head-command = "HEAD" [WS article-ref]
+     help-command = "HELP"
+     ihave-command = "IHAVE" WS message-id
+     last-command = "LAST"
+     list-command = "LIST" [WS list-arguments]
+     listgroup-command = "LISTGROUP" [WS newsgroup-name [WS range]]
+     mode-reader-command = "MODE" WS "READER"
+     newgroups-command = "NEWGROUPS" WS date-time
+     newnews-command = "NEWNEWS" WS wildmat WS date-time
+     next-command = "NEXT"
+     over-command = "OVER" [WS range-ref]
+
+
+
+Feather                     Standards Track                    [Page 92]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+     post-command = "POST"
+     quit-command = "QUIT"
+     stat-command = "STAT" [WS article-ref]
+
+     article-ref = article-number / message-id
+     date = date2y / date4y
+     date4y = 4DIGIT 2DIGIT 2DIGIT
+     date2y = 2DIGIT 2DIGIT 2DIGIT
+     date-time = date WS time [WS "GMT"]
+     header-meta-name = header-name / metadata-name
+     list-arguments = keyword [WS token]
+     metadata-name = ":" 1*A-NOTCOLON
+     range = article-number ["-" [article-number]]
+     range-ref = range / message-id
+     time = 2DIGIT 2DIGIT 2DIGIT
+
+9.3.  Command Continuation
+
+   This syntax defines the further material sent by the client in the
+   case of multi-stage commands and those that stream data.
+
+     command-datastream = UNDEFINED
+       ; not used, provided as a hook for extensions
+     command-continuation = ihave-335-continuation /
+           post-340-continuation
+
+     ihave-335-continuation = encoded-article
+     post-340-continuation = encoded-article
+
+     encoded-article = multi-line-data-block
+       ; after undoing the "dot-stuffing", this MUST match <article>
+
+9.4.  Responses
+
+9.4.1.  Generic Responses
+
+   This syntax defines the non-terminal <response>, which represents the
+   generic form of responses; that is, what is sent from the server to
+   the client in response to a <command> or a <command-continuation>.
+
+     response = simple-response / multi-line-response
+     simple-response = initial-response-line
+     multi-line-response = initial-response-line multi-line-data-block
+
+     initial-response-line =
+           initial-response-content [SP trailing-comment] CRLF
+     initial-response-content = X-initial-response-content
+     X-initial-response-content = 3DIGIT *(SP response-argument)
+
+
+
+Feather                     Standards Track                    [Page 93]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+     response-argument = 1*A-CHAR
+     trailing-comment = *U-CHAR
+
+9.4.2.  Initial Response Line Contents
+
+   This syntax defines the specific initial response lines for the
+   various commands in this specification (see section 3.1 for limits on
+   lengths).  Only those response codes with arguments are listed.
+
+     initial-response-content =/ response-111-content /
+           response-211-content /
+           response-220-content /
+           response-221-content /
+           response-222-content /
+           response-223-content /
+           response-401-content
+
+     response-111-content = "111" SP date4y time
+     response-211-content = "211" 3(SP article-number) SP newsgroup-name
+     response-220-content = "220" SP article-number SP message-id
+     response-221-content = "221" SP article-number SP message-id
+     response-222-content = "222" SP article-number SP message-id
+     response-223-content = "223" SP article-number SP message-id
+     response-401-content = "401" SP capability-label
+
+9.4.3.  Multi-line Response Contents
+
+   This syntax defines the content of the various multi-line responses;
+   more precisely, it defines the part of the response in the multi-line
+   data block after any "dot-stuffing" has been undone.  The numeric
+   portion of each non-terminal name indicates the response code that is
+   followed by this data.
+
+     multi-line-response-content = article-220-ml-content /
+           body-222-ml-content /
+           capabilities-101-ml-content /
+           hdr-225-ml-content /
+           head-221-ml-content /
+           help-100-ml-content /
+           list-215-ml-content /
+           listgroup-211-ml-content /
+           newgroups-231-ml-content /
+           newnews-230-ml-content /
+           over-224-ml-content
+
+     article-220-ml-content = article
+     body-222-ml-content = body
+     capabilities-101-ml-content = version-line CRLF
+
+
+
+Feather                     Standards Track                    [Page 94]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+           *(capability-line CRLF)
+     hdr-225-ml-content = *(article-number SP hdr-content CRLF)
+     head-221-ml-content = 1*header
+     help-100-ml-content = *(*U-CHAR CRLF)
+     list-215-ml-content = list-content
+     listgroup-211-ml-content = *(article-number CRLF)
+     newgroups-231-ml-content = active-groups-list
+     newnews-230-ml-content = *(message-id CRLF)
+     over-224-ml-content = *(article-number over-content CRLF)
+
+     active-groups-list = *(newsgroup-name SPA article-number
+           SPA article-number SPA newsgroup-status CRLF)
+     hdr-content = *S-NONTAB
+     hdr-n-content = [(header-name ":" / metadata-name) SP hdr-content]
+     list-content = body
+     newsgroup-status = %x79 / %x6E / %x6D / private-status
+     over-content = 1*6(TAB hdr-content) /
+           7(TAB hdr-content) *(TAB hdr-n-content)
+     private-status = token ; except the values in newsgroup-status
+
+9.5.  Capability Lines
+
+   This syntax defines the generic form of a capability line in the
+   capabilities list (see Section 3.3.1).
+
+     capability-line = capability-entry
+     capability-entry = X-capability-entry
+     X-capability-entry = capability-label *(WS capability-argument)
+     capability-label = keyword
+     capability-argument = token
+
+   This syntax defines the specific capability entries for the
+   capabilities in this specification.
+
+     capability-entry =/
+           hdr-capability /
+           ihave-capability /
+           implementation-capability /
+           list-capability /
+           mode-reader-capability /
+           newnews-capability /
+           over-capability /
+           post-capability /
+           reader-capability
+
+     hdr-capability = "HDR"
+     ihave-capability = "IHAVE"
+     implementation-capability = "IMPLEMENTATION" *(WS token)
+
+
+
+Feather                     Standards Track                    [Page 95]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+     list-capability = "LIST" 1*(WS keyword)
+     mode-reader-capability = "MODE-READER"
+     newnews-capability = "NEWNEWS"
+     over-capability = "OVER" [WS "MSGID"]
+     post-capability = "POST"
+     reader-capability = "READER"
+
+     version-line = "VERSION" 1*(WS version-number)
+     version-number = nzDIGIT *5DIGIT
+
+9.6.  LIST Variants
+
+   This section defines more specifically the keywords for the LIST
+   command and the syntax of the corresponding response contents.
+
+     ; active
+     list-arguments =/ "ACTIVE" [WS wildmat]
+     list-content =/ list-active-content
+     list-active-content = active-groups-list
+
+
+     ; active.times
+     list-arguments =/ "ACTIVE.TIMES" [WS wildmat]
+     list-content =/ list-active-times-content
+     list-active-times-content =
+           *(newsgroup-name SPA 1*DIGIT SPA newsgroup-creator CRLF)
+     newsgroup-creator = U-TEXT
+
+
+     ; distrib.pats
+     list-arguments =/ "DISTRIB.PATS"
+     list-content =/ list-distrib-pats-content
+     list-distrib-pats-content =
+           *(1*DIGIT ":" wildmat ":" distribution CRLF)
+     distribution = token
+
+
+     ; headers
+     list-arguments =/ "HEADERS" [WS ("MSGID" / "RANGE")]
+     list-content =/ list-headers-content
+     list-headers-content = *(header-meta-name CRLF) /
+           *((metadata-name / ":") CRLF)
+
+
+     ; newsgroups
+     list-arguments =/ "NEWSGROUPS" [WS wildmat]
+     list-content =/ list-newsgroups-content
+     list-newsgroups-content =
+
+
+
+Feather                     Standards Track                    [Page 96]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+           *(newsgroup-name WS newsgroup-description CRLF)
+     newsgroup-description = S-TEXT
+
+
+     ; overview.fmt
+     list-arguments =/ "OVERVIEW.FMT"
+     list-content =/ list-overview-fmt-content
+     list-overview-fmt-content = "Subject:" CRLF
+           "From:" CRLF
+           "Date:" CRLF
+           "Message-ID:" CRLF
+           "References:" CRLF
+           ( ":bytes" CRLF ":lines" / "Bytes:" CRLF "Lines:") CRLF
+           *((header-name ":full" / metadata-name) CRLF)
+
+9.7.  Articles
+
+   This syntax defines the non-terminal <article>, which represents the
+   format of an article as described in Section 3.6.
+
+     article = 1*header CRLF body
+     header = header-name ":" [CRLF] SP header-content CRLF
+     header-content = *(S-CHAR / [CRLF] WS)
+     body = *(*B-CHAR CRLF)
+
+9.8.  General Non-terminals
+
+   These non-terminals are used at various places in the syntax and are
+   collected here for convenience.  A few of these non-terminals are not
+   used in this specification but are provided for the consistency and
+   convenience of extension authors.
+
+     multi-line-data-block = content-lines termination
+     content-lines = *([content-text] CRLF)
+     content-text = (".." / B-NONDOT) *B-CHAR
+     termination = "." CRLF
+
+     article-number = 1*16DIGIT
+     header-name = 1*A-NOTCOLON
+     keyword = ALPHA 2*(ALPHA / DIGIT / "." / "-")
+     message-id = "<" 1*248A-NOTGT ">"
+     newsgroup-name = 1*wildmat-exact
+     token = 1*P-CHAR
+
+     wildmat = wildmat-pattern *("," ["!"] wildmat-pattern)
+     wildmat-pattern = 1*wildmat-item
+     wildmat-item = wildmat-exact / wildmat-wild
+     wildmat-exact = %x22-29 / %x2B / %x2D-3E / %x40-5A / %x5E-7E /
+
+
+
+Feather                     Standards Track                    [Page 97]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+          UTF8-non-ascii  ; exclude ! * , ? [ \ ]
+     wildmat-wild = "*" / "?"
+
+     base64 = *(4base64-char) [base64-terminal]
+     base64-char = UPPER / LOWER / DIGIT / "+" / "/"
+     base64-terminal = 2base64-char "==" / 3base64-char "="
+
+     ; Assorted special character sets
+     ;   A- means based on US-ASCII, excluding controls and SP
+     ;   P- means based on UTF-8, excluding controls and SP
+     ;   U- means based on UTF-8, excluding NUL CR and LF
+     ;   B- means based on bytes, excluding NUL CR and LF
+     A-CHAR     = %x21-7E
+     A-NOTCOLON = %x21-39 / %x3B-7E  ; exclude ":"
+     A-NOTGT    = %x21-3D / %x3F-7E  ; exclude ">"
+     P-CHAR     = A-CHAR / UTF8-non-ascii
+     U-CHAR     = CTRL / TAB / SP / A-CHAR / UTF8-non-ascii
+     U-NONTAB   = CTRL /       SP / A-CHAR / UTF8-non-ascii
+     U-TEXT     = P-CHAR *U-CHAR
+     B-CHAR     = CTRL / TAB / SP / %x21-FF
+     B-NONDOT   = CTRL / TAB / SP / %x21-2D / %x2F-FF  ; exclude "."
+
+     ALPHA = UPPER / LOWER   ; use only when case-insensitive
+     CR = %x0D
+     CRLF = CR LF
+     CTRL = %x01-08 / %x0B-0C / %x0E-1F
+     DIGIT = %x30-39
+     nzDIGIT = %x31-39
+     EOL = *(SP / TAB) CRLF
+     LF = %x0A
+     LOWER = %x61-7A
+     SP = %x20
+     SPA = 1*SP
+     TAB = %x09
+     UPPER = %x41-5A
+     UTF8-non-ascii = UTF8-2 / UTF8-3 / UTF8-4
+     UTF8-2    = %xC2-DF UTF8-tail
+     UTF8-3    = %xE0 %xA0-BF UTF8-tail / %xE1-EC 2UTF8-tail /
+                 %xED %x80-9F UTF8-tail / %xEE-EF 2UTF8-tail
+     UTF8-4    = %xF0 %x90-BF 2UTF8-tail / %xF1-F3 3UTF8-tail /
+                 %xF4 %x80-8F 2UTF8-tail
+     UTF8-tail = %x80-BF
+     WS = 1*(SP / TAB)
+
+   The following non-terminals require special consideration.  They
+   represent situations where material SHOULD be restricted to UTF-8,
+   but implementations MUST be able to cope with other character
+   encodings.  Therefore, there are two sets of definitions for them.
+
+
+
+Feather                     Standards Track                    [Page 98]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Implementations MUST accept any content that meets this syntax:
+
+     S-CHAR   = %x21-FF
+     S-NONTAB = CTRL / SP / S-CHAR
+     S-TEXT   = (CTRL / S-CHAR) *B-CHAR
+
+   and MAY pass such content on unaltered.
+
+   When generating new content or re-encoding existing content,
+   implementations SHOULD conform to this syntax:
+
+     S-CHAR   = P-CHAR
+     S-NONTAB = U-NONTAB
+     S-TEXT   = U-TEXT
+
+9.9.  Extensions and Validation
+
+   The specification of a registered extension MUST include formal
+   syntax that defines additional forms for the following non-terminals:
+
+   command
+      for each new command other than a variant of the LIST command -
+      the syntax of each command MUST be compatible with the definition
+      of <X-command>;
+
+   command-datastream
+      for each new command that immediately streams data;
+
+   command-continuation
+      for each new command that sends further material after the initial
+      command line - the syntax of each continuation MUST be exactly
+      what is sent to the server, including any escape mechanisms such
+      as "dot-stuffing";
+
+   initial-response-content
+      for each new response code that has arguments - the syntax of each
+      response MUST be compatible with the definition of <X-initial-
+      response-content>;
+
+   multi-line-response-content
+      for each new response code that has a multi-line response - the
+      syntax MUST show the response after the lines containing the
+      response code and the terminating octet have been removed and any
+      "dot-stuffing" undone;
+
+   capability-entry
+      for each new capability label - the syntax of each entry MUST be
+      compatible with the definition of <X-capability-entry>;
+
+
+
+Feather                     Standards Track                    [Page 99]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   list-arguments
+      for each new variant of the LIST command - the syntax of each
+      entry MUST be compatible with the definition of <X-command>;
+
+   list-content
+      for each new variant of the LIST command - the syntax MUST show
+      the response after the lines containing the 215 response code and
+      the terminating octet have been removed and any "dot-stuffing"
+      undone.
+
+   The =/ notation of ABNF [RFC4234] and the naming conventions
+   described in Section 9.1 SHOULD be used for this.
+
+   When the syntax in this specification, or syntax based on it, is
+   validated, it should be noted that:
+
+   o  the non-terminals <command-line>, <command-datastream>,
+      <command-continuation>, <response>, and
+      <multi-line-response-content> describe basic concepts of the
+      protocol and are not referred to by any other rule;
+
+   o  the non-terminal <base64> is provided for the convenience of
+      extension authors and is not referred to by any rule in this
+      specification;
+
+   o  for the reasons given above, the non-terminals <S-CHAR>,
+      <S-NONTAB>, and <S-TEXT> each have two definitions; and
+
+   o  the non-terminal <UNDEFINED> is deliberately not defined.
+
+10.  Internationalisation Considerations
+
+10.1.  Introduction and Historical Situation
+
+   RFC 977 [RFC977] was written at a time when internationalisation was
+   not seen as a significant issue.  As such, it was written on the
+   assumption that all communication would be in ASCII and use only a
+   7-bit transport layer, although in practice just about all known
+   implementations are 8-bit clean.
+
+   Since then, Usenet and NNTP have spread throughout the world.  In the
+   absence of standards for handling the issues of language and
+   character sets, countries, newsgroup hierarchies, and individuals
+   have found a variety of solutions that work for them but that are not
+   necessarily appropriate elsewhere.  For example, some have adopted a
+   default 8-bit character set appropriate to their needs (such as
+   ISO/IEC 8859-1 in Western Europe or KOI-8 in Russia), others have
+   used ASCII (either US-ASCII or national variants) in headers but
+
+
+
+Feather                     Standards Track                   [Page 100]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   local 16-bit character sets in article bodies, and still others have
+   gone for a combination of MIME [RFC2045] and UTF-8.  With the
+   increased use of MIME in email, it is becoming more common to find
+   NNTP articles containing MIME headers that identify the character set
+   of the body, but this is far from universal.
+
+   The resulting confusion does not help interoperability.
+
+   One point that has been generally accepted is that articles can
+   contain octets with the top bit set, and NNTP is only expected to
+   operate on 8-bit clean transport paths.
+
+10.2.  This Specification
+
+   Part of the role of this present specification is to eliminate this
+   confusion and promote interoperability as far as possible.  At the
+   same time, it is necessary to accept the existence of the present
+   situation and not break existing implementations and arrangements
+   gratuitously, even if they are less than optimal.  Therefore, the
+   current practice described above has been taken into consideration in
+   producing this specification.
+
+   This specification extends NNTP from US-ASCII [ANSI1986] to UTF-8
+   [RFC3629].  Except in the two areas discussed below, UTF-8 (which is
+   a superset of US-ASCII) is mandatory, and implementations MUST NOT
+   use any other encoding.
+
+   Firstly, the use of MIME for article headers and bodies is strongly
+   recommended.  However, given widely divergent existing practices, an
+   attempt to require a particular encoding and tagging standard would
+   be premature at this time.  Accordingly, this specification allows
+   the use of arbitrary 8-bit data in articles subject to the following
+   requirements and recommendations.
+
+   o  The names of headers (e.g., "From" or "Subject") MUST be in
+      US-ASCII.
+
+   o  Header values SHOULD use US-ASCII or an encoding based on it, such
+      as RFC 2047 [RFC2047], until such time as another approach has
+      been standardised.  At present, 8-bit encodings (including UTF-8)
+      SHOULD NOT be used because they are likely to cause
+      interoperability problems.
+
+   o  The character set of article bodies SHOULD be indicated in the
+      article headers, and this SHOULD be done in accordance with MIME.
+
+   o  Where an article is obtained from an external source, an
+      implementation MAY pass it on and derive data from it (such as the
+
+
+
+Feather                     Standards Track                   [Page 101]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+      response to the HDR command), even though the article or the data
+      does not meet the above requirements.  Implementations MUST
+      transfer such articles and data correctly and unchanged; they MUST
+      NOT attempt to convert or re-encode the article or derived data.
+      (Nevertheless, a client or server MAY elect not to post or forward
+      the article if, after further examination of the article, it deems
+      it inappropriate to do so.)
+
+   This requirement affects the ARTICLE (Section 6.2.1), BODY
+   (Section 6.2.3), HDR (Section 8.5), HEAD (Section 6.2.2), IHAVE
+   (Section 6.3.2), OVER (Section 8.3), and POST (Section 6.3.1)
+   commands.
+
+   Secondly, the following requirements are placed on the newsgroups
+   list returned by the LIST NEWSGROUPS command (Section 7.6.6):
+
+   o  Although this specification allows UTF-8 for newsgroup names, they
+      SHOULD be restricted to US-ASCII until a successor to RFC 1036
+      [RFC1036] standardises another approach. 8-bit encodings SHOULD
+      NOT be used because they are likely to cause interoperability
+      problems.
+
+   o  The newsgroup description SHOULD be in US-ASCII or UTF-8 unless
+      and until a successor to RFC 1036 standardises other encoding
+      arrangements.  8-bit encodings other than UTF-8 SHOULD NOT be used
+      because they are likely to cause interoperability problems.
+
+   o  Implementations that obtain this data from an external source MUST
+      handle it correctly even if it does not meet the above
+      requirements.  Implementations (in particular, clients) MUST
+      handle such data correctly.
+
+10.3.  Outstanding Issues
+
+   While the primary use of NNTP is for transmitting articles that
+   conform to RFC 1036 (Netnews articles), it is also used for other
+   formats (see Appendix A).  It is therefore most appropriate that
+   internationalisation issues related to article formats be addressed
+   in the relevant specifications.  For Netnews articles, this is any
+   successor to RFC 1036.  For email messages, it is RFC 2822 [RFC2822].
+
+   Of course, any article transmitted via NNTP needs to conform to this
+   specification as well.
+
+   Restricting newsgroup names to UTF-8 is not a complete solution.  In
+   particular, when new newsgroup names are created or a user is asked
+   to enter a newsgroup name, some scheme of canonicalisation will need
+   to take place.  This specification does not attempt to define that
+
+
+
+Feather                     Standards Track                   [Page 102]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   canonicalization; further work is needed in this area, in conjunction
+   with the article format specifications.  Until such specifications
+   are published, implementations SHOULD match newsgroup names octet by
+   octet.  It is anticipated that any approved scheme will be applied
+   "at the edges", and therefore octet-by-octet comparison will continue
+   to apply to most, if not all, uses of newsgroup names in NNTP.
+
+   In the meantime, any implementation experimenting with UTF-8
+   newsgroup names is strongly cautioned that a future specification may
+   require that those names be canonicalized when used with NNTP in a
+   way that is not compatible with their experiments.
+
+   Since the primary use of NNTP is with Netnews, and since newsgroup
+   descriptions are normally distributed through specially formatted
+   articles, it is recommended that the internationalisation issues
+   related to them be addressed in any successor to RFC 1036.
+
+11.  IANA Considerations
+
+   This specification requires IANA to keep a registry of capability
+   labels.  The initial contents of this registry are specified in
+   Section 3.3.4.  As described in Section 3.3.3, labels beginning with
+   X are reserved for private use, while all other names are expected to
+   be associated with a specification in an RFC on the standards track
+   or defining an IESG-approved experimental protocol.
+
+   Different entries in the registry MUST use different capability
+   labels.
+
+   Different entries in the registry MUST NOT use the same command name.
+   For this purpose, variants distinguished by a second or subsequent
+   keyword (e.g., "LIST HEADERS" and "LIST OVERVIEW.FMT") count as
+   different commands.  If there is a need for two extensions to use the
+   same command, a single harmonised specification MUST be registered.
+
+12.  Security Considerations
+
+   This section is meant to inform application developers, information
+   providers, and users of the security limitations in NNTP as described
+   by this document.  The discussion does not include definitive
+   solutions to the problems revealed, though it does make some
+   suggestions for reducing security risks.
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 103]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+12.1.  Personal and Proprietary Information
+
+   NNTP, because it was created to distribute network news articles,
+   will forward whatever information is stored in those articles.
+   Specification of that information is outside this scope of this
+   document, but it is likely that some personal and/or proprietary
+   information is available in some of those articles.  It is very
+   important that designers and implementers provide informative
+   warnings to users so that personal and/or proprietary information in
+   material that is added automatically to articles (e.g., in headers)
+   is not disclosed inadvertently.  Additionally, effective and easily
+   understood mechanisms to manage the distribution of news articles
+   SHOULD be provided to NNTP Server administrators, so that they are
+   able to report with confidence the likely spread of any particular
+   set of news articles.
+
+12.2.  Abuse of Server Log Information
+
+   A server is in the position to save session data about a user's
+   requests that might identify their reading patterns or subjects of
+   interest.  This information is clearly confidential in nature, and
+   its handling can be constrained by law in certain countries.  People
+   using this protocol to provide data are responsible for ensuring that
+   such material is not distributed without the permission of any
+   individuals that are identifiable by the published results.
+
+12.3.  Weak Authentication and Access Control
+
+   There is no user-based or token-based authentication in the basic
+   NNTP specification.  Access is normally controlled by server
+   configuration files.  Those files specify access by using domain
+   names or IP addresses.  However, this specification does permit the
+   creation of extensions to NNTP for such purposes; one such extension
+   is [NNTP-AUTH].  While including such mechanisms is optional, doing
+   so is strongly encouraged.
+
+   Other mechanisms are also available.  For example, a proxy server
+   could be put in place that requires authentication before connecting
+   via the proxy to the NNTP server.
+
+12.4.  DNS Spoofing
+
+   Many existing NNTP implementations authorize incoming connections by
+   checking the IP address of that connection against the IP addresses
+   obtained via DNS lookups of lists of domain names given in local
+   configuration files.  Servers that use this type of authentication
+   and clients that find a server by doing a DNS lookup of the server
+   name rely very heavily on the Domain Name Service, and are thus
+
+
+
+Feather                     Standards Track                   [Page 104]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   generally prone to security attacks based on the deliberate
+   misassociation of IP addresses and DNS names.  Clients and servers
+   need to be cautious in assuming the continuing validity of an IP
+   number/DNS name association.
+
+   In particular, NNTP clients and servers SHOULD rely on their name
+   resolver for confirmation of an IP number/DNS name association,
+   rather than cache the result of previous host name lookups.  Many
+   platforms already can cache host name lookups locally when
+   appropriate, and they SHOULD be configured to do so.  It is proper
+   for these lookups to be cached, however, only when the TTL (Time To
+   Live) information reported by the name server makes it likely that
+   the cached information will remain useful.
+
+   If NNTP clients or servers cache the results of host name lookups in
+   order to achieve a performance improvement, they MUST observe the TTL
+   information reported by DNS.  If NNTP clients or servers do not
+   observe this rule, they could be spoofed when a previously accessed
+   server's IP address changes.  As network renumbering is expected to
+   become increasingly common, the possibility of this form of attack
+   will increase.  Observing this requirement thus reduces this
+   potential security vulnerability.
+
+   This requirement also improves the load-balancing behaviour of
+   clients for replicated servers using the same DNS name and reduces
+   the likelihood of a user's experiencing failure in accessing sites
+   that use that strategy.
+
+12.5.  UTF-8 Issues
+
+   UTF-8 [RFC3629] permits only certain sequences of octets and
+   designates others as either malformed or "illegal".  The Unicode
+   standard identifies a number of security issues related to illegal
+   sequences and forbids their generation by conforming implementations.
+
+   Implementations of this specification MUST NOT generate malformed or
+   illegal sequences and SHOULD detect them and take some appropriate
+   action.  This could include the following:
+
+   o  Generating a 501 response code.
+
+   o  Replacing such sequences by the sequence %xEF.BF.BD, which encodes
+      the "replacement character" U+FFFD.
+
+   o  Closing the connection.
+
+   o  Replacing such sequences by a "guessed" valid sequence (based on
+      properties of the UTF-8 encoding).
+
+
+
+Feather                     Standards Track                   [Page 105]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   In the last case, the implementation MUST ensure that any replacement
+   cannot be used to bypass validity or security checks.  For example,
+   the illegal sequence %xC0.A0 is an over-long encoding for space
+   (%x20).  If it is replaced by the correct encoding in a command line,
+   this needs to happen before the command line is parsed into
+   individual arguments.  If the replacement came after parsing, it
+   would be possible to generate an argument with an embedded space,
+   which is forbidden.  Use of the "replacement character" does not have
+   this problem, since it is permitted wherever non-US-ASCII characters
+   are.  Implementations SHOULD use one of the first two solutions where
+   the general structure of the NNTP stream remains intact and SHOULD
+   close the connection if it is no longer possible to parse it
+   sensibly.
+
+12.6.  Caching of Capability Lists
+
+   The CAPABILITIES command provides a capability list, which is
+   information about the current capabilities of the server.  Whenever
+   there is a relevant change to the server state, the results of this
+   command are required to change accordingly.
+
+   In most situations, the capabilities list in a given server state
+   will not change from session to session; for example, a given
+   extension will be installed permanently on a server.  Some clients
+   may therefore wish to remember which extensions a server supports to
+   avoid the delay of an additional command and response, particularly
+   if they open multiple connections in the same session.
+
+   However, information about extensions related to security and privacy
+   MUST NOT be cached, since this could allow a variety of attacks.
+
+   For example, consider a server that permits the use of cleartext
+   passwords on links that are encrypted but not otherwise:
+
+      [Initial connection set-up completed.]
+      [S] 200 NNTP Service Ready, posting permitted
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] NEWNEWS
+      [S] POST
+      [S] XENCRYPT
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+      [C] XENCRYPT
+      [Client and server negotiate encryption on the link]
+      [S] 283 Encrypted link established
+
+
+
+Feather                     Standards Track                   [Page 106]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] NEWNEWS
+      [S] POST
+      [S] XSECRET
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+      [C] XSECRET fred flintstone
+      [S] 290 Password for fred accepted
+
+   If the client caches the last capabilities list, then on the next
+   session it will attempt to use XSECRET on an unencrypted link:
+
+      [Initial connection set-up completed.]
+      [S] 200 NNTP Service Ready, posting permitted
+      [C] XSECRET fred flintstone
+      [S] 483 Only permitted on secure links
+
+   This exposes the password to any eavesdropper.  While the primary
+   cause of this is passing a secret without first checking the security
+   of the link, caching of capability lists can increase the risk.
+
+   Any security extension should include requirements to check the
+   security state of the link in a manner appropriate to that extension.
+
+   Caching should normally only be considered for anonymous clients that
+   do not use any security or privacy extensions and for which the time
+   required for an additional command and response is a noticeable
+   issue.
+
+13.  Acknowledgements
+
+   This document is the result of much effort by the present and past
+   members of the NNTP Working Group, chaired by Russ Allbery and Ned
+   Freed.  It could not have been produced without them.
+
+   The author acknowledges the original authors of NNTP as documented in
+   RFC 977 [RFC977]: Brian Kantor and Phil Lapsey.
+
+   The author gratefully acknowledges the following:
+
+   o  The work of the NNTP committee chaired by Eliot Lear.  The
+      organization of this document was influenced by the last available
+      version from this working group.  A special thanks to Eliot for
+      generously providing the original machine-readable sources for
+      that document.
+
+
+
+Feather                     Standards Track                   [Page 107]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   o  The work of the DRUMS working group, specifically RFC 1869
+      [RFC1869], that drove the original thinking that led to the
+      CAPABILITIES command and the extensions mechanism detailed in this
+      document.
+
+   o  The authors of RFC 2616 [RFC2616] for providing specific and
+      relevant examples of security issues that should be considered for
+      HTTP.  Since many of the same considerations exist for NNTP, those
+      examples that are relevant have been included here with some minor
+      rewrites.
+
+   o  The comments and additional information provided by the following
+      individuals in preparing one or more of the progenitors of this
+      document:
+
+         Russ Allbery <rra@stanford.edu>
+         Wayne Davison <davison@armory.com>
+         Chris Lewis <clewis@bnr.ca>
+         Tom Limoncelli <tal@mars.superlink.net>
+         Eric Schnoebelen <eric@egsner.cirr.com>
+         Rich Salz <rsalz@osf.org>
+
+   This work was motivated by the work of various news reader authors
+   and news server authors, including those listed below:
+
+   Rick Adams
+      Original author of the NNTP extensions to the RN news reader and
+      last maintainer of Bnews.
+
+   Stan Barber
+      Original author of the NNTP extensions to the news readers that
+      are part of Bnews.
+
+   Geoff Collyer
+      Original author of the OVERVIEW database proposal and one of the
+      original authors of CNEWS.
+
+   Dan Curry
+      Original author of the xvnews news reader.
+
+   Wayne Davison
+      Author of the first threading extensions to the RN news reader
+      (commonly called TRN).
+
+   Geoff Huston
+      Original author of ANU NEWS.
+
+
+
+
+
+Feather                     Standards Track                   [Page 108]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Phil Lapsey
+      Original author of the UNIX reference implementation for NNTP.
+
+   Iain Lea
+      Original maintainer of the TIN news reader.
+
+   Chris Lewis
+      First known implementer of the AUTHINFO GENERIC extension.
+
+   Rich Salz
+      Original author of INN.
+
+   Henry Spencer
+      One of the original authors of CNEWS.
+
+   Kim Storm
+      Original author of the NN news reader.
+
+   Other people who contributed to this document include:
+
+      Matthias Andree
+      Greg Andruk
+      Daniel Barclay
+      Maurizio Codogno
+      Mark Crispin
+      Andrew Gierth
+      Juergen Helbing
+      Scott Hollenbeck
+      Urs Janssen
+      Charles Lindsey
+      Ade Lovett
+      David Magda
+      Ken Murchison
+      Francois Petillon
+      Peter Robinson
+      Rob Siemborski
+      Howard Swinehart
+      Ruud van Tol
+      Jeffrey Vinocur
+      Erik Warmelink
+
+   The author thanks them all and apologises to anyone omitted.
+
+   Finally, the present author gratefully acknowledges the vast amount
+   of work put into previous versions by the previous author:
+
+      Stan Barber <sob@academ.com>
+
+
+
+
+Feather                     Standards Track                   [Page 109]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+14.  References
+
+14.1.  Normative References
+
+   [ANSI1986]    American National Standards Institute, "Coded Character
+                 Set - 7-bit American Standard Code for Information
+                 Interchange", ANSI X3.4, 1986.
+
+   [RFC977]      Kantor, B. and P. Lapsley, "Network News Transfer
+                 Protocol", RFC 977, February 1986.
+
+   [RFC2045]     Freed, N. and N. Borenstein, "Multipurpose Internet
+                 Mail Extensions (MIME) Part One: Format of Internet
+                 Message Bodies", RFC 2045, November 1996.
+
+   [RFC2047]     Moore, K., "MIME (Multipurpose Internet Mail
+                 Extensions) Part Three: Message Header Extensions for
+                 Non-ASCII Text", RFC 2047, November 1996.
+
+   [RFC2119]     Bradner, S., "Key words for use in RFCs to Indicate
+                 Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3629]     Yergeau, F., "UTF-8, a transformation format of ISO
+                 10646", STD 63, RFC 3629, November 2003.
+
+   [RFC4234]     Crocker, D., Ed. and P. Overell, "Augmented BNF for
+                 Syntax Specifications: ABNF", RFC 4234, October 2005.
+
+   [RFC4648]     Josefsson, S., "The Base16, Base32, and Base64 Data
+                 Encodings", RFC 4648, October 2006.
+
+   [TF.686-1]    International Telecommunications Union - Radio,
+                 "Glossary, ITU-R Recommendation TF.686-1",
+                 ITU-R Recommendation TF.686-1, October 1997.
+
+14.2.  Informative References
+
+   [NNTP-AUTH]   Vinocur, J., Murchison, K., and C. Newman, "Network
+                 News Transfer Protocol (NNTP) Extension for
+                 Authentication",
+                 RFC 4643, October 2006.
+
+   [NNTP-STREAM] Vinocur, J. and K. Murchison, "Network News Transfer
+                 Protocol (NNTP) Extension for Streaming Feeds",
+                 RFC 4644, October 2006.
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 110]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   [NNTP-TLS]    Murchison, K., Vinocur, J., and C. Newman, "Using
+                 Transport Layer Security (TLS) with Network News
+                 Transfer Protocol (NNTP)", RFC 4642, October 2006.
+
+   [RFC1036]     Horton, M. and R. Adams, "Standard for interchange of
+                 USENET messages", RFC 1036, December 1987.
+
+   [RFC1305]     Mills, D., "Network Time Protocol (Version 3)
+                 Specification, Implementation and Analysis", RFC 1305,
+                 March 1992.
+
+   [RFC1869]     Klensin, J., Freed, N., Rose, M., Stefferud, E., and D.
+                 Crocker, "SMTP Service Extensions", STD 10, RFC 1869,
+                 November 1995.
+
+   [RFC2616]     Fielding,  R., Gettys, J., Mogul, J., Frystyk, H.,
+                 Masinter, L., Leach, P., and T. Berners-Lee, "Hypertext
+                 Transfer Protocol -- HTTP/1.1", RFC 2616, June 1999.
+
+   [RFC2629]     Rose, M., "Writing I-Ds and RFCs using XML", RFC 2629,
+                 June 1999.
+
+   [RFC2822]     Resnick, P., "Internet Message Format", RFC 2822, April
+                 2001.
+
+   [RFC2980]     Barber, S., "Common NNTP Extensions", RFC 2980, October
+                 2000.
+
+   [ROBE1995]    Robertson, R., "FAQ: Overview database / NOV General
+                 Information", January 1995.
+
+                 There is no definitive copy of this document known to
+                 the author.  It was previously posted as the Usenet
+                 article <news:nov-faq-1-930909720@agate.Berkeley.EDU>
+
+   [SALZ1992]    Salz, R., "Manual Page for wildmat(3) from the INN 1.4
+                 distribution, Revision 1.10", April 1992.
+
+                 There is no definitive copy of this document known to
+                 the author.
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 111]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+Appendix A.  Interaction with Other Specifications
+
+   NNTP is most often used for transferring articles that conform to
+   RFC 1036 [RFC1036] (such articles are called "Netnews articles"
+   here).  It is also sometimes used for transferring email messages
+   that conform to RFC 2822 [RFC2822] (such articles are called "email
+   articles" here).  In this situation, articles must conform both to
+   this specification and to that other one; this appendix describes
+   some relevant issues.
+
+A.1.  Header Folding
+
+   NNTP allows a header line to be folded (by inserting a CRLF pair)
+   before any space or TAB character.
+
+   Both email and Netnews articles are required to have at least one
+   octet other than space or TAB on each header line.  Thus, folding can
+   only happen at one point in each sequence of consecutive spaces or
+   TABs.  Netnews articles are further required to have the header name,
+   colon, and following space all on the first line; folding may only
+   happen beyond that space.  Finally, some non-conforming software will
+   remove trailing spaces and TABs from a line.  Therefore, it might be
+   inadvisable to fold a header after a space or TAB.
+
+   For maximum safety, header lines SHOULD conform to the following
+   syntax rather than to that in Section 9.7.
+
+
+     header = header-name ":" SP [header-content] CRLF
+     header-content = [WS] token *( [CRLF] WS token )
+
+A.2.  Message-IDs
+
+   Every article handled by an NNTP server MUST have a unique
+   message-id.  For the purposes of this specification, a message-id is
+   an arbitrary opaque string that merely needs to meet certain
+   syntactic requirements and is just a way to refer to the article.
+
+   Because there is a significant risk that old articles will be
+   reinjected into the global Usenet system, RFC 1036 [RFC1036] requires
+   that message-ids are globally unique for all time.
+
+   This specification states that message-ids are the same if and only
+   if they consist of the same sequence of octets.  Other specifications
+   may define two different sequences as being equal because they are
+   putting an interpretation on particular characters.  RFC 2822
+   [RFC2822] has a concept of "quoted" and "escaped" characters.  It
+   therefore considers the three message-ids:
+
+
+
+Feather                     Standards Track                   [Page 112]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+      <ab.cd@example.com>
+      <"ab.cd"@example.com>
+      <"ab.\cd"@example.com>
+
+   as being identical.  Therefore, an NNTP implementation handing email
+   articles must ensure that only one of these three appears in the
+   protocol and that the other two are converted to it as and when
+   necessary, such as when a client checks the results of a NEWNEWS
+   command against an internal database of message-ids.  Note that
+   RFC 1036 [RFC1036] never treats two different strings as being
+   identical.  Its successor (as of the time of writing) restricts the
+   syntax of message-ids so that, whenever RFC 2822 would treat two
+   strings as equivalent, only one of them is valid (in the above
+   example, only the first string is valid).
+
+   This specification does not describe how the message-id of an article
+   is determined; it may be deduced from the contents of the article or
+   derived from some external source.  If the server is also conforming
+   to another specification that contains a definition of message-id
+   compatible with this one, the server SHOULD use those message-ids.  A
+   common approach, and one that SHOULD be used for email and Netnews
+   articles, is to extract the message-id from the contents of a header
+   with name "Message-ID".  This may not be as simple as copying the
+   entire header contents; it may be necessary to strip off comments and
+   undo quoting, or to reduce "equivalent" message-ids to a canonical
+   form.
+
+   If an article is obtained through the IHAVE command, there will be a
+   message-id provided with the command.  The server MAY either use it
+   or determine one from the article contents.  However, whichever it
+   does, it SHOULD ensure that, if the IHAVE command is repeated with
+   the same argument and article, it will be recognized as a duplicate.
+
+   If an article does not contain a message-id that the server can
+   identify, it MUST synthesize one.  This could, for example, be a
+   simple sequence number or be based on the date and time when the
+   article arrived.  When email or Netnews articles are handled, a
+   Message-ID header SHOULD be added to ensure global consistency and
+   uniqueness.
+
+   Note that, because the message-id might not have been derived from
+   the Message-ID header in the article, the following example is
+   legitimate (though unusual):
+
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 113]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+      [C] HEAD <45223423@example.com>
+      [S] 221 0 <45223423@example.com>
+      [S] Path: pathost!demo!whitehouse!not-for-mail
+      [S] Message-ID: <1234@example.net>
+      [S] From: "Demo User" <nobody@example.net>
+      [S] Newsgroups: misc.test
+      [S] Subject: I am just a test article
+      [S] Date: 6 Oct 1998 04:38:40 -0500
+      [S] Organization: An Example Net, Uncertain, Texas
+      [S] .
+
+A.3.  Article Posting
+
+   As far as NNTP is concerned, the POST and IHAVE commands provide the
+   same basic facilities in a slightly different way.  However, they
+   have rather different intentions.
+
+   The IHAVE command is intended for transmitting conforming articles
+   between a system of NNTP servers, with all articles perhaps also
+   conforming to another specification (e.g., all articles are Netnews
+   articles).  It is expected that the client will already have done any
+   necessary validation (or that it has in turn obtained the article
+   from a third party that has done so); therefore, the contents SHOULD
+   be left unchanged.
+
+   In contrast, the POST command is intended for use when an end-user is
+   injecting a newly created article into a such a system.  The article
+   being transferred might not be a conforming email or Netnews article,
+   and the server is expected to validate it and, if necessary, to
+   convert it to the right form for onward distribution.  This is often
+   done by a separate piece of software on the server installation; if
+   so, the NNTP server SHOULD pass the incoming article to that software
+   unaltered, making no attempt to filter characters, to fold or limit
+   lines, or to process the incoming text otherwise.
+
+   The POST command can fail in various ways, and clients should be
+   prepared to re-send an article.  When doing so, however, it is often
+   important to ensure (as far as possible) that the same message-id is
+   allocated to both attempts so that the server, or other servers, can
+   recognize the two articles as duplicates.  In the case of email or
+   Netnews articles, therefore, the posted article SHOULD contain a
+   header with the name "Message-ID", and the contents of this header
+   SHOULD be identical on each attempt.  The server SHOULD ensure that
+   two POSTed articles with the same contents for this header are
+   recognized as identical and that the same message-id is allocated,
+   whether or not those contents are suitable for use as the message-id.
+
+
+
+
+
+Feather                     Standards Track                   [Page 114]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+Appendix B.  Summary of Commands
+
+   This section contains a list of every command defined in this
+   document, ordered by command name and by indicating capability.
+
+                         Ordered by command name:
+
+       +-------------------+-----------------------+---------------+
+       | Command           | Indicating capability | Definition    |
+       +-------------------+-----------------------+---------------+
+       | ARTICLE           | READER                | Section 6.2.1 |
+       | BODY              | READER                | Section 6.2.3 |
+       | CAPABILITIES      | mandatory             | Section 5.2   |
+       | DATE              | READER                | Section 7.1   |
+       | GROUP             | READER                | Section 6.1.1 |
+       | HDR               | HDR                   | Section 8.5   |
+       | HEAD              | mandatory             | Section 6.2.2 |
+       | HELP              | mandatory             | Section 7.2   |
+       | IHAVE             | IHAVE                 | Section 6.3.2 |
+       | LAST              | READER                | Section 6.1.3 |
+       | LIST              | LIST                  | Section 7.6.1 |
+       | LIST ACTIVE.TIMES | LIST                  | Section 7.6.4 |
+       | LIST ACTIVE       | LIST                  | Section 7.6.3 |
+       | LIST DISTRIB.PATS | LIST                  | Section 7.6.5 |
+       | LIST HEADERS      | HDR                   | Section 8.6   |
+       | LIST NEWSGROUPS   | LIST                  | Section 7.6.6 |
+       | LIST OVERVIEW.FMT | OVER                  | Section 8.4   |
+       | LISTGROUP         | READER                | Section 6.1.2 |
+       | MODE READER       | MODE-READER           | Section 5.3   |
+       | NEWGROUPS         | READER                | Section 7.3   |
+       | NEWNEWS           | NEWNEWS               | Section 7.4   |
+       | NEXT              | READER                | Section 6.1.4 |
+       | OVER              | OVER                  | Section 8.3   |
+       | POST              | POST                  | Section 6.3.1 |
+       | QUIT              | mandatory             | Section 5.4   |
+       | STAT              | mandatory             | Section 6.2.4 |
+       +-------------------+-----------------------+---------------+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 115]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+                     Ordered by indicating capability:
+
+       +-------------------+-----------------------+---------------+
+       | Command           | Indicating capability | Definition    |
+       +-------------------+-----------------------+---------------+
+       | CAPABILITIES      | mandatory             | Section 5.2   |
+       | HEAD              | mandatory             | Section 6.2.2 |
+       | HELP              | mandatory             | Section 7.2   |
+       | QUIT              | mandatory             | Section 5.4   |
+       | STAT              | mandatory             | Section 6.2.4 |
+       | HDR               | HDR                   | Section 8.5   |
+       | LIST HEADERS      | HDR                   | Section 8.6   |
+       | IHAVE             | IHAVE                 | Section 6.3.2 |
+       | LIST              | LIST                  | Section 7.6.1 |
+       | LIST ACTIVE       | LIST                  | Section 7.6.3 |
+       | LIST ACTIVE.TIMES | LIST                  | Section 7.6.4 |
+       | LIST DISTRIB.PATS | LIST                  | Section 7.6.5 |
+       | LIST NEWSGROUPS   | LIST                  | Section 7.6.6 |
+       | MODE READER       | MODE-READER           | Section 5.3   |
+       | NEWNEWS           | NEWNEWS               | Section 7.4   |
+       | OVER              | OVER                  | Section 8.3   |
+       | LIST OVERVIEW.FMT | OVER                  | Section 8.4   |
+       | POST              | POST                  | Section 6.3.1 |
+       | ARTICLE           | READER                | Section 6.2.1 |
+       | BODY              | READER                | Section 6.2.3 |
+       | DATE              | READER                | Section 7.1   |
+       | GROUP             | READER                | Section 6.1.1 |
+       | LAST              | READER                | Section 6.1.3 |
+       | LISTGROUP         | READER                | Section 6.1.2 |
+       | NEWGROUPS         | READER                | Section 7.3   |
+       | NEXT              | READER                | Section 6.1.4 |
+       +-------------------+-----------------------+---------------+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 116]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+Appendix C.  Summary of Response Codes
+
+   This section contains a list of every response code defined in this
+   document and indicates whether it is multi-line, which commands can
+   generate it, what arguments it has, and what its meaning is.
+
+   Response code 100 (multi-line)
+      Generated by: HELP
+      Meaning: help text follows.
+
+   Response code 101 (multi-line)
+      Generated by: CAPABILITIES
+      Meaning: capabilities list follows.
+
+   Response code 111
+      Generated by: DATE
+      1 argument: yyyymmddhhmmss
+      Meaning: server date and time.
+
+   Response code 200
+      Generated by: initial connection, MODE READER
+      Meaning: service available, posting allowed.
+
+   Response code 201
+      Generated by: initial connection, MODE READER
+      Meaning: service available, posting prohibited.
+
+   Response code 205
+      Generated by: QUIT
+      Meaning: connection closing (the server immediately closes the
+      connection).
+
+   Response code 211
+      The 211 response code has two completely different forms,
+      depending on which command generated it:
+
+         (not multi-line)
+         Generated by: GROUP
+         4 arguments: number low high group
+         Meaning: group selected.
+
+         (multi-line)
+         Generated by: LISTGROUP
+         4 arguments: number low high group
+         Meaning: article numbers follow.
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 117]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Response code 215 (multi-line)
+      Generated by: LIST
+      Meaning: information follows.
+
+   Response code 220 (multi-line)
+      Generated by: ARTICLE
+      2 arguments: n message-id
+      Meaning: article follows.
+
+   Response code 221 (multi-line)
+      Generated by: HEAD
+      2 arguments: n message-id
+      Meaning: article headers follow.
+
+   Response code 222 (multi-line)
+      Generated by: BODY
+      2 arguments: n message-id
+      Meaning: article body follows.
+
+   Response code 223
+      Generated by: LAST, NEXT, STAT
+      2 arguments: n message-id
+      Meaning: article exists and selected.
+
+   Response code 224 (multi-line)
+      Generated by: OVER
+      Meaning: overview information follows.
+
+   Response code 225 (multi-line)
+      Generated by: HDR
+      Meaning: headers follow.
+
+   Response code 230 (multi-line)
+      Generated by: NEWNEWS
+      Meaning: list of new articles follows.
+
+   Response code 231 (multi-line)
+      Generated by: NEWGROUPS
+      Meaning: list of new newsgroups follows.
+
+   Response code 235
+      Generated by: IHAVE (second stage)
+      Meaning: article transferred OK.
+
+   Response code 240
+      Generated by: POST (second stage)
+      Meaning: article received OK.
+
+
+
+
+Feather                     Standards Track                   [Page 118]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Response code 335
+      Generated by: IHAVE (first stage)
+      Meaning: send article to be transferred.
+
+   Response code 340
+      Generated by: POST (first stage)
+      Meaning: send article to be posted.
+
+   Response code 400
+      Generic response and generated by initial connection
+      Meaning: service not available or no longer available (the server
+      immediately closes the connection).
+
+   Response code 401
+      Generic response
+      1 argument: capability-label
+      Meaning: the server is in the wrong mode; the indicated capability
+      should be used to change the mode.
+
+   Response code 403
+      Generic response
+      Meaning: internal fault or problem preventing action being taken.
+
+   Response code 411
+      Generated by: GROUP, LISTGROUP
+      Meaning: no such newsgroup.
+
+   Response code 412
+      Generated by: ARTICLE, BODY, GROUP, HDR, HEAD, LAST, LISTGROUP,
+      NEXT, OVER, STAT
+      Meaning: no newsgroup selected.
+
+   Response code 420
+      Generated by: ARTICLE, BODY, HDR, HEAD, LAST, NEXT, OVER, STAT
+      Meaning: current article number is invalid.
+
+   Response code 421
+      Generated by: NEXT
+      Meaning: no next article in this group.
+
+   Response code 422
+      Generated by: LAST
+      Meaning: no previous article in this group.
+
+   Response code 423
+      Generated by: ARTICLE, BODY, HDR, HEAD, OVER, STAT
+      Meaning: no article with that number or in that range.
+
+
+
+
+Feather                     Standards Track                   [Page 119]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Response code 430
+      Generated by: ARTICLE, BODY, HDR, HEAD, OVER, STAT
+      Meaning: no article with that message-id.
+
+   Response code 435
+      Generated by: IHAVE (first stage)
+      Meaning: article not wanted.
+
+   Response code 436
+      Generated by: IHAVE (either stage)
+      Meaning: transfer not possible (first stage) or failed (second
+      stage); try again later.
+
+   Response code 437
+      Generated by: IHAVE (second stage)
+      Meaning: transfer rejected; do not retry.
+
+   Response code 440
+      Generated by: POST (first stage)
+      Meaning: posting not permitted.
+
+   Response code 441
+      Generated by: POST (second stage)
+      Meaning: posting failed.
+
+   Response code 480
+      Generic response
+      Meaning: command unavailable until the client has authenticated
+      itself.
+
+   Response code 483
+      Generic response
+      Meaning: command unavailable until suitable privacy has been
+      arranged.
+
+   Response code 500
+      Generic response
+      Meaning: unknown command.
+
+   Response code 501
+      Generic response
+      Meaning: syntax error in command.
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 120]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   Response code 502
+      Generic response and generated by initial connection
+
+      Meaning for the initial connection and the MODE READER command:
+      service permanently unavailable (the server immediately closes the
+      connection).
+
+      Meaning for all other commands: command not permitted (and there
+      is no way for the client to change this).
+
+   Response code 503
+      Generic response
+      Meaning: feature not supported.
+
+   Response code 504
+      Generic response
+      Meaning: error in base64-encoding [RFC4648] of an argument.
+
+Appendix D.  Changes from RFC 977
+
+   In general every attempt has been made to ensure that the protocol
+   specification in this document is compatible with the version
+   specified in RFC 977 [RFC977] and the various facilities adopted from
+   RFC 2980 [RFC2980].  However, there have been a number of changes,
+   some compatible and some not.
+
+   This appendix lists these changes.  It is not guaranteed to be
+   exhaustive or correct and MUST NOT be relied on.
+
+   o  A formal syntax specification (Section 9) has been added.
+
+   o  The default character set is changed from US-ASCII [ANSI1986] to
+      UTF-8 [RFC3629] (note that US-ASCII is a subset of UTF-8).  This
+      matter is discussed further in Section 10.
+
+   o  All articles are required to have a message-id, eliminating the
+      "<0>" placeholder used in RFC 977 in some responses.
+
+   o  The newsgroup name matching capabilities already documented in
+      RFC 977 ("wildmats", Section 4) are clarified and extended.  The
+      new facilities (e.g., the use of commas and exclamation marks) are
+      allowed wherever wildmats appear in the protocol.
+
+   o  Support for pipelining of commands (Section 3.5) is made
+      mandatory.
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 121]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   o  The principles behind response codes (Section 3.2) have been
+      tidied up.  In particular:
+
+      *  the x8x response code family, formerly used for private
+         extensions, is now reserved for authentication and privacy
+         extensions;
+
+      *  the x9x response code family, formerly intended for debugging
+         facilities, are now reserved for private extensions;
+
+      *  the 502 and 503 generic response codes (Section 3.2.1) have
+         been redefined;
+
+      *  new 401, 403, 480, 483, and 504 generic response codes have
+         been added.
+
+   o  The rules for article numbering (Section 6) have been clarified
+      (also see Section 6.1.1.2).
+
+   o  The SLAVE command (which was ill-defined) is removed from the
+      protocol.
+
+   o  Four-digit years are permitted in the NEWNEWS (Section 7.4) and
+      NEWGROUPS (Section 7.3) commands (two-digit years are still
+      permitted).  The optional distribution parameter to these commands
+      has been removed.
+
+   o  The LIST command (Section 7.6.1) is greatly extended; the original
+      is available as LIST ACTIVE, while new variants include
+      ACTIVE.TIMES, DISTRIB.PATS, and NEWSGROUPS.  A new "m" status flag
+      is added to the LIST ACTIVE response.
+
+   o  A new CAPABILITIES command (Section 5.2) allows clients to
+      determine what facilities are supported by a server.
+
+   o  The DATE command (Section 7.1) is adopted from RFC 2980
+      effectively unchanged.
+
+   o  The LISTGROUP command (Section 6.1.2) is adopted from RFC 2980.
+      An optional range argument has been added, and the 211 initial
+      response line now has the same format as the 211 response from the
+      GROUP command.
+
+   o  The MODE READER command (Section 5.3) is adopted from RFC 2980 and
+      its meaning and effects clarified.
+
+   o  The XHDR command in RFC 2980 has been formalised as the new HDR
+      (Section 8.5) and LIST HEADERS (Section 8.6) commands.
+
+
+
+Feather                     Standards Track                   [Page 122]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+   o  The XOVER command in RFC 2980 has been formalised as the new OVER
+      (Section 8.3) and LIST OVERVIEW.FMT (Section 8.4) commands.  The
+      former can be applied to a message-id as well as to a range.
+
+   o  The concept of article metadata (Section 8.1) has been formalised,
+      allowing the Bytes and Lines pseudo-headers to be deprecated.
+
+   Client authors should note in particular that lack of support for the
+   CAPABILITIES command is a good indication that the server does not
+   support this specification.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 123]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+Author's Address
+
+   Clive D.W. Feather
+   THUS plc
+   322 Regents Park Road
+   London
+   N3  2QQ
+   United Kingdom
+
+   Phone: +44 20 8495 6138
+   Fax:   +44 870 051 9937
+   EMail: clive@demon.net
+   URI:   http://www.davros.org/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 124]
+
+RFC 3977         Network News Transfer Protocol (NNTP)      October 2006
+
+
+Full Copyright Statement
+
+Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Feather                     Standards Track                   [Page 125]
+

--- a/doc/rfc4643.txt
+++ b/doc/rfc4643.txt
@@ -1,0 +1,1347 @@
+
+
+
+
+
+
+Network Working Group                                         J. Vinocur
+Request for Comments: 4643                            Cornell University
+Updates: 2980                                               K. Murchison
+Category: Standards Track                     Carnegie Mellon University
+                                                            October 2006
+
+
+                 Network News Transfer Protocol (NNTP)
+                      Extension for Authentication
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This document defines an extension to the Network News Transfer
+   Protocol (NNTP) that allows a client to indicate an authentication
+   mechanism to the server, to perform an authentication protocol
+   exchange, and optionally to negotiate a security layer for subsequent
+   protocol interactions during the remainder of an NNTP session.
+
+   This document updates and formalizes the AUTHINFO USER/PASS
+   authentication method specified in RFC 2980 and deprecates the
+   AUTHINFO SIMPLE and AUTHINFO GENERIC authentication methods.
+   Additionally, this document defines a profile of the Simple
+   Authentication and Security Layer (SASL) for NNTP.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vinocur, et al.             Standards Track                     [Page 1]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+Table of Contents
+
+   1. Introduction .............................................  3
+      1.1. Conventions Used in This Document ...................  3
+   2. The AUTHINFO Extension ...................................  4
+      2.1. Advertising the AUTHINFO Extension ..................  4
+      2.2. Authenticating with the AUTHINFO Extension ..........  5
+      2.3. AUTHINFO USER/PASS Command ..........................  6
+           2.3.1. Usage ........................................  7
+           2.3.2. Description ..................................  7
+           2.3.3. Examples .....................................  9
+      2.4. AUTHINFO SASL Command ...............................  9
+           2.4.1. Usage ........................................ 10
+           2.4.2. Description .................................. 11
+           2.4.3. Examples ..................................... 14
+   3. Augmented BNF Syntax for the AUTHINFO Extension .......... 16
+      3.1. Commands ............................................ 16
+      3.2. Command Continuation ................................ 17
+      3.3. Responses ........................................... 17
+      3.4. Capability Entries .................................. 17
+      3.5. General Non-terminals ............................... 18
+   4. Summary of Response Codes ................................ 18
+   5. Authentication Tracking/Logging .......................... 18
+   6. Security Considerations .................................. 19
+   7. IANA Considerations ...................................... 20
+      7.1. IANA Considerations for SASL/GSSAPI Services ........ 20
+      7.2. IANA Considerations for NNTP Extensions ............. 20
+   8. Acknowledgements ......................................... 21
+   9. References ............................................... 22
+      9.1. Normative References ................................ 22
+      9.2. Informative References .............................. 22
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vinocur, et al.             Standards Track                     [Page 2]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+1.  Introduction
+
+   Although NNTP [NNTP] has traditionally been used to provide public
+   access to newsgroups, authentication is often useful for several
+   purposes; for example, to control resource consumption, to allow
+   abusers of the POST command to be identified, and to restrict access
+   to "local" newsgroups.
+
+   The ad-hoc AUTHINFO USER and AUTHINFO PASS commands, documented in
+   [NNTP-COMMON], provide a very weak authentication mechanism in
+   widespread use by the installed base.  Due to their ubiquity, they
+   are formalized in this specification but (because of their
+   insecurity) only for use in combination with appropriate security
+   layers.
+
+   The ad hoc AUTHINFO GENERIC command, also documented in [NNTP-COMMON]
+   but much less ubiquitous, provided an NNTP-specific equivalent of the
+   generic SASL [SASL] facility.  This document deprecates AUTHINFO
+   GENERIC in favor of an AUTHINFO SASL replacement so that NNTP can
+   benefit from authentication mechanisms developed for other SASL-
+   enabled application protocols, including Simple Mail Transfer
+   Protocol (SMTP) [SMTP-AUTH], Post Office Protocol (POP) [POP-AUTH],
+   Internet Message Access Protocol (IMAP) [IMAP], Lightweight Directory
+   Access Protocol (LDAP) [LDAP-AUTH], and Blocks Extensive Exchange
+   Protocol (BEEP) [BEEP].
+
+   This specification is to be read in conjunction with the NNTP base
+   specification [NNTP].  Except where specifically stated otherwise, in
+   the case of a conflict between these two documents, [NNTP] takes
+   precedence over this one.
+
+   It is also recommended that this specification be read in conjunction
+   with the SASL base specification [SASL].
+
+1.1.  Conventions Used in This Document
+
+   The notational conventions used in this document are the same as
+   those in [NNTP], and any term not defined in this document has the
+   same meaning as it does in that one.
+
+   The key words "REQUIRED", "MUST", "MUST NOT", "SHOULD", "SHOULD NOT",
+   "MAY", and "OPTIONAL" in this document are to be interpreted as
+   described in "Key words for use in RFCs to Indicate Requirement
+   Levels" [KEYWORDS].
+
+   Terms related to authentication are defined in "On Internet
+   Authentication" [AUTH].
+
+
+
+
+Vinocur, et al.             Standards Track                     [Page 3]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   In the examples, commands from the client are indicated with [C], and
+   responses from the server are indicated with [S].
+
+2.  The AUTHINFO Extension
+
+   The AUTHINFO extension is used to authenticate a user.  Note that
+   authorization is a matter of site policy, not network protocol, and
+   therefore it is not discussed in this document.  The server
+   determines authorization in whatever manner is defined by its
+   implementation as configured by the site administrator.
+
+   This extension provides three new commands: AUTHINFO USER, AUTHINFO
+   PASS, and AUTHINFO SASL.  The capability label for this extension is
+   AUTHINFO.
+
+2.1.  Advertising the AUTHINFO Extension
+
+   A server MUST implement at least one of the AUTHINFO USER or AUTHINFO
+   SASL commands in order to advertise the "AUTHINFO" capability label
+   in response to the CAPABILITIES command ([NNTP] Section 5.2).
+   However, this capability MUST NOT be advertised after successful
+   authentication (see Section 2.2).  This capability MAY be advertised
+   both before and after any use of the MODE READER command ([NNTP]
+   Section 5.3), with the same semantics.
+
+   The AUTHINFO capability label contains an argument list detailing
+   which authentication commands are available.
+
+   The "USER" argument indicates that AUTHINFO USER/PASS is supported as
+   defined by Section 2.3 of this document.  The "USER" argument MUST
+   NOT be advertised, and the AUTHINFO USER/PASS commands SHOULD NOT be
+   provided, unless a strong encryption layer (e.g., Transport Layer
+   Security (TLS) [NNTP-TLS]) is in use or backward compatibility
+   dictates otherwise.
+
+   The "SASL" argument indicates that AUTHINFO SASL is supported as
+   defined by Section 2.4 of this document.  If the server advertises
+   the "SASL" argument, then it MUST also advertise the "SASL"
+   capability in response to the CAPABILITIES command.  The SASL
+   capability is followed by a whitespace-separated list of available
+   SASL mechanism names.
+
+   The server MAY list the AUTHINFO capability with no arguments, which
+   indicates that it complies with this specification and does not
+   permit any authentication commands in its current state.  In this
+   case, the client MUST NOT attempt to utilize any AUTHINFO commands,
+   even if it contains logic that might otherwise cause it to do so
+
+
+
+
+Vinocur, et al.             Standards Track                     [Page 4]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   (e.g., for backward compatibility with servers that are not compliant
+   with this specification).
+
+   Future extensions may add additional arguments to this capability.
+   Unrecognized arguments MUST be ignored by the client.
+
+   As the AUTHINFO command is related to security, cached results of
+   CAPABILITIES from a previous session MUST NOT be relied on, as per
+   Section 12.6 of [NNTP].  However, a client MAY use such cached
+   results in order to detect active down-negotiation attacks.
+
+   Example of AUTHINFO capabilities before and after the use of the
+   STARTTLS [NNTP-TLS] extension:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] IHAVE
+      [S] STARTTLS
+      [S] AUTHINFO SASL
+      [S] SASL CRAM-MD5 DIGEST-MD5 GSSAPI
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+      [C] STARTTLS
+      [S] 382 Continue with TLS negotiation
+      [TLS negotiation proceeds, further commands protected by TLS]
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] IHAVE
+      [S] AUTHINFO USER SASL
+      [S] SASL CRAM-MD5 DIGEST-MD5 GSSAPI PLAIN EXTERNAL
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+
+2.2.  Authenticating with the AUTHINFO Extension
+
+   An NNTP server responds to a client command with a 480 response to
+   indicate that the client MUST authenticate and/or authorize in order
+   to use that command or access the indicated resource.  Use of the
+   AUTHINFO command as described below is one such way that a client can
+   authenticate/authorize to the server.  The client MAY therefore use
+   an AUTHINFO command after receiving a 480 response.  A client
+   intending to use an AUTHINFO command SHOULD issue the CAPABILITIES
+   command to obtain the available authentication commands and
+   mechanisms before attempting authentication.
+
+
+
+Vinocur, et al.             Standards Track                     [Page 5]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   If a server advertises the AUTHINFO capability, a client MAY attempt
+   the first step of authentication at any time during a session to
+   acquire additional privileges without having received a 480 response.
+   Servers SHOULD accept such unsolicited authentication requests.  A
+   server MUST NOT under any circumstances reply to an AUTHINFO command
+   with a 480 response.
+
+   A client MUST NOT under any circumstances continue with any steps of
+   authentication beyond the first, unless the response code from the
+   server indicates that the authentication exchange is welcomed.  In
+   particular, anything other than a 38x response code indicates that
+   the client MUST NOT continue the authentication exchange.
+
+   After a successful authentication, the client MUST NOT issue another
+   AUTHINFO command in the same session.  A server MUST NOT return the
+   AUTHINFO capability in response to a CAPABILITIES command, and a
+   server MUST reject any subsequent AUTHINFO commands with a 502
+   response.  Additionally, the client MUST NOT issue a MODE READER
+   command after authentication, and a server MUST NOT advertise the
+   MODE-READER capability.
+
+   In agreement with [SASL], the server MUST continue to advertise the
+   SASL capability in response to a CAPABILITIES command with the same
+   list of SASL mechanisms that it did before authentication (thereby
+   enabling the client to detect a possible active down-negotiation
+   attack).  Other capabilities returned in response to a CAPABILITIES
+   command received after authentication MAY be different from those
+   returned before authentication.  For example, an NNTP server may not
+   want to advertise support for a specific extension unless a client
+   has been authenticated.
+
+   Note that a server may perform a successful authentication exchange
+   with a client and yet still deny access to some or all resources; the
+   permanent 502 response indicates that a resource is unavailable even
+   though authentication has been performed (this is in contrast to the
+   temporary 480 error, which indicates that a resource is unavailable
+   now but may become available after authentication).
+
+2.3.  AUTHINFO USER/PASS Command
+
+   This section supersedes the definition of the AUTHINFO USER and
+   AUTHINFO PASS commands as documented in Section 3.1.1 of
+   [NNTP-COMMON].
+
+
+
+
+
+
+
+
+Vinocur, et al.             Standards Track                     [Page 6]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+2.3.1.  Usage
+
+   These commands MUST NOT be pipelined.
+
+   Syntax
+     AUTHINFO USER username
+     AUTHINFO PASS password
+
+   Responses
+     281 Authentication accepted
+     381 Password required [1]
+     481 Authentication failed/rejected
+     482 Authentication commands issued out of sequence
+     502 Command unavailable [2]
+
+     [1] Only valid for AUTHINFO USER.  Note that unlike traditional 3xx
+         codes, which indicate that the client may continue the current
+         command, the legacy 381 code means that the AUTHINFO PASS
+         command must be used to complete the authentication exchange.
+
+     [2] If authentication has already occurred, AUTHINFO USER/PASS are
+         not valid commands (see Section 2.2).
+
+         NOTE: Notwithstanding Section 3.2.1 of [NNTP], the server MUST
+         NOT return 480 in response to AUTHINFO USER/PASS.
+
+   Parameters
+     username = string identifying the user/client
+     password = string representing the user's password
+
+2.3.2.  Description
+
+   The AUTHINFO USER and AUTHINFO PASS commands are used to present
+   clear text credentials to the server.  These credentials consist of a
+   username or a username plus a password (the distinction is that a
+   password is expected to be kept secret, whereas a username is not;
+   this does not directly affect the protocol but may have an impact on
+   user interfaces).  The username is supplied through the AUTHINFO USER
+   command, and the password through the AUTHINFO PASS command.
+
+   If the server requires only a username, it MUST NOT give a 381
+   response to AUTHINFO USER and MUST give a 482 response to AUTHINFO
+   PASS.
+
+   If the server requires both username and password, the former MUST be
+   sent before the latter.  The server will need to cache the username
+   until the password is received; it MAY require that the password be
+
+
+
+
+Vinocur, et al.             Standards Track                     [Page 7]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   sent in the immediately next command (in other words, only caching
+   the username until the next command is sent).  The server:
+
+   -  MUST return a 381 response to AUTHINFO USER;
+
+   -  MUST return a 482 response to AUTHINFO PASS if there is no cached
+      username;
+
+   -  MUST use the argument of the most recent AUTHINFO USER for
+      authentication; and
+
+   -  MUST NOT return a 381 response to AUTHINFO PASS.
+
+   The server MAY determine whether a password is needed for a given
+   username.  Thus the same server can respond with both 381 and other
+   response codes to AUTHINFO USER.
+
+   Should the client successfully present proper credentials, the server
+   issues a 281 reply.  If the server is unable to authenticate the
+   client, it MUST reject the AUTHINFO USER/PASS command with a 481
+   reply.  If an AUTHINFO USER/PASS command fails, the client MAY
+   proceed without authentication.  Alternatively, the client MAY try
+   another authentication mechanism or present different credentials by
+   issuing another AUTHINFO command.
+
+   The AUTHINFO PASS command permits the client to use a clear-text
+   password to authenticate.  A compliant implementation MUST NOT
+   implement this command without also implementing support for TLS
+   [NNTP-TLS].  Use of this command without an active strong encryption
+   layer is deprecated, as it exposes the user's password to all parties
+   on the network between the client and the server.  Any implementation
+   of this command SHOULD be configurable to disable it whenever a
+   strong encryption layer (such as that provided by [NNTP-TLS]) is not
+   active, and this configuration SHOULD be the default.  The server
+   will use the 483 response code to indicate that the datastream is
+   insufficiently secure for the command being attempted (see Section
+   3.2.1 of [NNTP]).
+
+   Note that a server MAY (but is not required to) allow white space
+   characters in usernames and passwords.  A server implementation MAY
+   blindly split command arguments at white space and therefore may not
+   preserve the exact sequence of white space characters in the username
+   or password.  Therefore, a client SHOULD scan the username and
+   password for white space and, if any is detected, warn the user of
+   the likelihood of problems.  The SASL PLAIN [PLAIN] mechanism is
+   recommended as an alternative, as it does not suffer from these
+   issues.
+
+
+
+
+Vinocur, et al.             Standards Track                     [Page 8]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   Also note that historically the username is not canonicalized in any
+   way.  Servers MAY use the [SASLprep] profile of the [StringPrep]
+   algorithm to prepare usernames for comparison, but doing so may cause
+   interoperability problems with legacy implementations.  If
+   canonicalization is desired, the SASL PLAIN [PLAIN] mechanism is
+   recommended as an alternative.
+
+2.3.3.  Examples
+
+   Example of successful AUTHINFO USER:
+
+      [C] AUTHINFO USER wilma
+      [S] 281 Authentication accepted
+
+   Example of successful AUTHINFO USER/PASS:
+
+      [C] AUTHINFO USER fred
+      [S] 381 Enter passphrase
+      [C] AUTHINFO PASS flintstone
+      [S] 281 Authentication accepted
+
+   Example of AUTHINFO USER/PASS requiring a security layer:
+
+      [C] AUTHINFO USER fred@stonecanyon.example.com
+      [S] 483 Encryption or stronger authentication required
+
+   Example of failed AUTHINFO USER/PASS:
+
+      [C] AUTHINFO USER barney
+      [S] 381 Enter passphrase
+      [C] AUTHINFO PASS flintstone
+      [S] 481 Authentication failed
+
+   Example of AUTHINFO PASS before AUTHINFO USER:
+
+      [C] AUTHINFO PASS flintstone
+      [S] 482 Authentication commands issued out of sequence
+
+2.4.  AUTHINFO SASL Command
+
+   This section defines a formal profile of the Simple Authentication
+   and Security Layer [SASL].  The use of the AUTHINFO GENERIC command
+   as documented in Section 3.1.3 of [NNTP-COMMON], as a way to perform
+   SASL authentication, is deprecated in favor of the AUTHINFO SASL
+   command.  A server SHOULD NOT advertise AUTHINFO GENERIC in the list
+   of capabilities returned by CAPABILITIES.
+
+
+
+
+
+Vinocur, et al.             Standards Track                     [Page 9]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+2.4.1.  Usage
+
+   This command MUST NOT be pipelined.
+
+   Syntax
+      AUTHINFO SASL mechanism [initial-response]
+
+   This command MAY exceed 512 octets.  The maximum length of this
+   command is increased to that which can accommodate the largest
+   encoded initial response possible for any of the SASL mechanisms
+   supported by the implementation.
+
+   Responses
+     281             Authentication accepted
+     283 challenge   Authentication accepted (with success data) [1]
+     383 challenge   Continue with SASL exchange [1]
+     481             Authentication failed/rejected
+     482             SASL protocol error
+     502             Command unavailable [2]
+
+     [1] These responses MAY exceed 512 octets.  The maximum length of
+         these responses is increased to that which can accommodate the
+         largest encoded challenge possible for any of the SASL
+         mechanisms supported by the implementation.
+
+     [2] If authentication has already occurred, AUTHINFO SASL is not a
+         valid command (see Section 2.2).
+
+         NOTE: Notwithstanding Section 3.2.1 of [NNTP], the server MUST
+         NOT return 480 in response to AUTHINFO SASL.
+
+   Parameters
+     mechanism         = String identifying a [SASL] authentication
+                         mechanism.
+     initial-response  = Optional initial client response.
+                         If present, the response MUST be encoded as
+                         specified in Section 4 of [BASE64]. [3]
+     challenge         = Server challenge.
+                         The challenge MUST be encoded as specified
+                         in Section 4 of [BASE64].
+
+     [3] This argument MAY exceed 497 octets.  The maximum length of
+         this argument is increased to that which can accommodate the
+         largest encoded initial response possible for any of the SASL
+         mechanisms supported by the implementation.
+
+
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 10]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+2.4.2.  Description
+
+   The AUTHINFO SASL command initiates a [SASL] exchange between the
+   client and the server.  The client identifies the SASL mechanism to
+   be used with the first parameter of the AUTHINFO SASL command.  If
+   the server supports the requested authentication mechanism, it
+   performs the SASL exchange to authenticate the user.  Optionally, it
+   also negotiates a security layer for subsequent protocol interactions
+   during this session.  If the requested authentication mechanism is
+   invalid (e.g., is not supported), the server rejects the AUTHINFO
+   SASL command with a 503 reply (see Section 3.2.1 of [NNTP]).  If the
+   requested authentication mechanism requires an encryption layer, the
+   server rejects the AUTHINFO SASL command with a 483 reply (see
+   Section 3.2.1 of [NNTP]).
+
+   The service name specified by this protocol's profile of SASL is
+   "nntp".
+
+   The SASL exchange consists of a series of server challenges and
+   client responses that are specific to the chosen [SASL] mechanism.
+
+   A server challenge is sent as a 383 reply with a single argument
+   containing the [BASE64]-encoded string supplied by the SASL
+   mechanism.  A server challenge that has zero length MUST be sent as a
+   single equals sign ("=") and MUST be included (in order to comply
+   with the [NNTP] requirement that responses always have the same
+   number of arguments).
+
+   A client response consists of a line containing a [BASE64]-encoded
+   string.  A client response that has zero length MUST be sent as a
+   single equals sign ("=") and MUST be included (for consistency with
+   the server challenge format).  If the client wishes to cancel the
+   authentication exchange, it issues a line with a single "*".  If the
+   server receives such a response, it MUST reject the AUTHINFO SASL
+   command by sending a 481 reply.
+
+   Note that these [BASE64]-encoded strings can be much longer than
+   normal NNTP responses.  Clients and servers MUST be able to handle
+   the maximum encoded size of challenges and responses generated by
+   their supported authentication mechanisms.  This requirement is
+   independent of any line length limitations the client or server may
+   have in other parts of its protocol implementation.
+
+   The optional initial response argument to the AUTHINFO SASL command
+   is used to save a round trip when using authentication mechanisms
+   that support an initial client response.  If the initial response
+   argument is omitted and the chosen mechanism requires an initial
+   client response, the server MUST proceed as defined in section 5.1 of
+
+
+
+Vinocur, et al.             Standards Track                    [Page 11]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   [SASL].  In NNTP, a server challenge that contains no data is
+   equivalent to a zero-length challenge and is encoded as a single
+   equals sign ("=").
+
+   Note that the [BASE64]-encoded initial response argument can exceed
+   497 octets, and therefore that the AUTHINFO SASL command can exceed
+   512 octets.  Clients SHOULD and servers MUST be able to handle the
+   maximum encoded size of initial responses possible for their
+   supported authentication mechanisms.  This requirement is independent
+   of any command or argument length limitations the client or server
+   may have in other parts of its protocol implementation.
+
+   If use of the initial response argument would cause the AUTHINFO SASL
+   command to exceed 512 octets, the client MAY choose to omit the
+   initial response parameter (and instead proceed as defined in Section
+   5.1 of [SASL]).
+
+   If the client is transmitting an initial response of zero length, it
+   MUST instead transmit the response as a single equals sign ("=").
+   This indicates that the response is present, but that it contains no
+   data.
+
+   If the client uses an initial-response argument to the AUTHINFO SASL
+   command with a SASL mechanism that does not support an initial client
+   response, the server MUST reject the AUTHINFO SASL command with a 482
+   reply.
+
+   If the server cannot [BASE64] decode any client response, it MUST
+   reject the AUTHINFO SASL command with a 504 reply (see Section 3.2.1
+   of [NNTP]).  If the client cannot BASE64 decode any of the server's
+   challenges, it MUST cancel the authentication using the "*" response.
+   In particular, servers and clients MUST reject (and not ignore) any
+   character not explicitly allowed by the BASE64 alphabet, and they
+   MUST reject any sequence of BASE64 characters that contains the pad
+   character ('=') anywhere other than the end of the string (e.g.,
+   "=AAA" and "AAA=BBB" are not allowed).
+
+   The authorization identity generated by this [SASL] exchange is a
+   simple username, and both client and server MUST use the [SASLprep]
+   profile of the [StringPrep] algorithm to prepare these names for
+   transmission or comparison.  If preparation of the authorization
+   identity fails or results in an empty string (unless it was
+   transmitted as the empty string), the server MUST fail the
+   authentication with a 481 reply.
+
+   Should the client successfully complete the exchange, the server
+   issues either a 281 or a 283 reply.  If the server is unable to
+   authenticate the client, it MUST reject the AUTHINFO SASL command
+
+
+
+Vinocur, et al.             Standards Track                    [Page 12]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   with a 481 reply.  If an AUTHINFO SASL command fails, the client MAY
+   proceed without authentication.  Alternatively, the client MAY try
+   another authentication mechanism, or present different credentials by
+   issuing another AUTHINFO command.
+
+   If the SASL mechanism returns additional data on success (e.g.,
+   server authentication), the NNTP server issues a 283 reply with a
+   single argument containing the [BASE64]-encoded string supplied by
+   the SASL mechanism.  If no additional data is returned on success,
+   the server issues a 281 reply.
+
+   If a security layer is negotiated during the SASL exchange, it takes
+   effect for the client on the octet immediately following the CRLF
+   that concludes the last response generated by the client.  For the
+   server, it takes effect immediately following the CRLF of its success
+   reply.
+
+   When a security layer takes effect, the NNTP protocol is reset to the
+   state immediately after the initial greeting response (see 5.1 of
+   [NNTP]) has been sent, with the exception that if a MODE READER
+   command has been issued, the effects of it (if any) are not reversed.
+   The server MUST discard any knowledge obtained from the client, such
+   as the current newsgroup and article number, that was not obtained
+   from the SASL negotiation itself.  Likewise, the client SHOULD
+   discard and MUST NOT rely on any knowledge obtained from the server,
+   such as the capability list, that was not obtained from the SASL
+   negotiation itself.  (Note that a client MAY compare the advertised
+   SASL mechanisms before and after authentication in order to detect an
+   active down-negotiation attack.)
+
+   When both TLS [NNTP-TLS] and SASL security layers are in effect, the
+   TLS encoding MUST be applied after the SASL encoding (the cleartext
+   data is always SASL encoded first, and then the resultant data is TLS
+   encoded).
+
+   To ensure interoperability, client and server implementations of this
+   extension MUST implement the [DIGEST-MD5] SASL mechanism.
+
+   If AUTHINFO USER/PASS and AUTHINFO SASL are both implemented, the
+   SASL [PLAIN] mechanism SHOULD also be implemented, as the
+   functionality of DIGEST-MD5 is insufficient for some environments
+   (e.g., the server may need to pass off the plaintext password to an
+   external authentication service).  The SASL PLAIN mechanism is
+   preferred over AUTHINFO USER, even if there is not a strong
+   encryption layer active, because it eliminates limitations that
+   AUTHINFO USER/PASS has with regards to the use of white space
+   characters being used in usernames and passwords.
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 13]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+2.4.3.  Examples
+
+   Example of the [PLAIN] SASL mechanism under a TLS layer, using an
+   initial client response:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] STARTTLS
+      [S] AUTHINFO SASL
+      [S] SASL CRAM-MD5 DIGEST-MD5 GSSAPI
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+      [C] STARTTLS
+      [S] 382 Continue with TLS negotiation
+      [TLS negotiation proceeds, further commands protected by TLS]
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] AUTHINFO USER SASL
+      [S] SASL CRAM-MD5 DIGEST-MD5 GSSAPI PLAIN EXTERNAL
+      [S] LIST ACTIVE NEWSGROUPS
+      [S] .
+      [C] AUTHINFO SASL PLAIN AHRlc3QAMTIzNA==
+      [S] 281 Authentication accepted
+
+   Example of the EXTERNAL SASL mechanism under a TLS layer, using the
+   authorization identity derived from the client TLS certificate, and
+   thus a zero-length initial client response (commands prior to
+   AUTHINFO SASL are the same as the previous example and have been
+   omitted):
+
+      [C] AUTHINFO SASL EXTERNAL =
+      [S] 281 Authentication accepted
+
+   Example of the [DIGEST-MD5] SASL mechanism, which includes a server
+   challenge and server success data (white space has been inserted for
+   clarity; base64-encoded data is actually sent as a single line with
+   no embedded white space):
+
+      [C] AUTHINFO SASL DIGEST-MD5
+      [S] 383 bm9uY2U9InNheUFPaENFS0dJZFBNSEMwd3RsZUxxT0ljT0kyd1FZSWU0
+          enplQXR1aVE9IixyZWFsbT0iZWFnbGUub2NlYW5hLmNvbSIscW9wPSJhdXRo
+          LGF1dGgtaW50LGF1dGgtY29uZiIsY2lwaGVyPSJyYzQtNDAscmM0LTU2LHJj
+          NCxkZXMsM2RlcyIsbWF4YnVmPTQwOTYsY2hhcnNldD11dGYtOCxhbGdvcml0
+          aG09bWQ1LXNlc3M=
+
+
+
+Vinocur, et al.             Standards Track                    [Page 14]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+      [C] dXNlcm5hbWU9InRlc3QiLHJlYWxtPSJlYWdsZS5vY2VhbmEuY29tIixub25j
+          ZT0ic2F5QU9oQ0VLR0lkUE1IQzB3dGxlTHFPSWNPSTJ3UVlJZTR6emVBdHVp
+          UT0iLGNub25jZT0iMFkzSlFWMlRnOVNjRGlwK08xU1ZDMHJoVmcvLytkbk9J
+          aUd6LzdDZU5KOD0iLG5jPTAwMDAwMDAxLHFvcD1hdXRoLWNvbmYsY2lwaGVy
+          PXJjNCxtYXhidWY9MTAyNCxkaWdlc3QtdXJpPSJubnRwL2xvY2FsaG9zdCIs
+          cmVzcG9uc2U9ZDQzY2Y2NmNmZmE5MDNmOWViMDM1NmMwOGEzZGIwZjI=
+      [S] 283 cnNwYXV0aD1kZTJlMTI3ZTVhODFjZGE1M2Q5N2FjZGEzNWNkZTgzYQ==
+
+   Example of a failed authentication due to bad [GSSAPI] credentials.
+   Note that although the mechanism can utilize the initial response,
+   the client chooses not to use it because of its length, resulting in
+   a zero-length server challenge (here, white space has been inserted
+   for clarity; base64-encoded data is actually sent as a single line
+   with no embedded white space):
+
+      [C] AUTHINFO SASL GSSAPI
+      [S] 383 =
+      [C] YIICOAYJKoZIhvcSAQICAQBuggInMIICI6ADAgEFoQMCAQ6iBwMFACAAAACj
+          ggE/YYIBOzCCATegAwIBBaEYGxZURVNULk5FVC5JU0MuVVBFTk4uRURVoiQw
+          IqADAgEDoRswGRsEbmV3cxsRbmV0bmV3cy51cGVubi5lZHWjge8wgeygAwIB
+          EKEDAgECooHfBIHcSQfLKC8vm2i17EXmomwk6hHvjBY/BnKnvvDTrbno3198
+          vlX2RSUt+CjuAKhcDcj4DW0gvZEqH7t5v9yWedzztlpaThebBat6hQNr9NJP
+          ozh1/+74HUwhGWb50KtjuftO/ftQ8q0nTuYKgIq6PM4tp2ddo1IfpjfdNR9E
+          95GFi3y1uBT7lQOwtQbRJUjPSO3ijdue9V7cNNVmYsBsqNsaHhvlBJEXf4WJ
+          djH8yG+Dw/gX8fUTtC5fDpB5zLt01mkSXh6Wc4UhqQtwZBI2t/+TpX1okbg6
+          Hr1ZZupeH6SByjCBx6ADAgEQooG/BIG8GnCmcXWtqhXh48dGTLHQgJ04K5Fj
+          RMMq2qPSbiha9lq0osqR2KAnQA6LioWYxU+6yPKpBDSC5WOT441fUfkM8iAL
+          kW3uNc+luFCGcnDsacrmoVU7Y6Akcp9m7Fm7orRc+TWSWPpBg3OR2oG3ATW0
+          0NAz8TT06VOLVxIMUTINKdYVI/Ja7f3sy+/N4LGkJqScCQOwlo5tfDWn/UQF
+          iTWo5Zw435rH8pjy2smQCnqC14v3NMAWTu4j+dzHUNw=
+      [S] 481 Authentication error
+
+   Example of a client aborting in the midst of an exchange:
+
+      [C] AUTHINFO SASL GSSAPI
+      [S] 383 =
+      [C] *
+      [S] 481 Authentication aborted as requested
+
+   Example of attempting to use a mechanism that is not supported by the
+   server:
+
+      [C] AUTHINFO SASL EXAMPLE
+      [S] 503 Mechanism not recognized
+
+
+
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 15]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   Example of attempting to use a mechanism that requires a security
+   layer:
+
+      [C] AUTHINFO SASL PLAIN
+      [S] 483 Encryption or stronger authentication required
+
+   Example of using an initial response with a mechanism that doesn't
+   support it (the server must start the exchange when using
+   [CRAM-MD5]):
+
+      [C] AUTHINFO SASL CRAM-MD5 AHRlc3QAMTIzNA==
+      [S] 482 SASL protocol error
+
+   Example of an authentication that failed due to an incorrectly
+   encoded response:
+
+      [C] AUTHINFO SASL CRAM-MD5
+      [S] 383 PDE1NDE2NzQ5My4zMjY4MzE3QHRlc3RAZXhhbXBsZS5jb20+
+      [C] abcd=efg
+      [S] 504 Base64 encoding error
+
+3.  Augmented BNF Syntax for the AUTHINFO Extension
+
+   This section describes the formal syntax of the AUTHINFO extension
+   using ABNF [ABNF].  It extends the syntax in Section 9 of [NNTP], and
+   non-terminals not defined in this document are defined there.  The
+   [NNTP] ABNF should be imported first before attempting to validate
+   these rules.
+
+3.1.  Commands
+
+   This syntax extends the non-terminal "command", which represents an
+   NNTP command.
+
+   command =/ authinfo-sasl-command /
+        authinfo-user-command /
+        authinfo-pass-command
+
+   authinfo-sasl-command = "AUTHINFO" WS "SASL" WS mechanism
+        [WS initial-response]
+   authinfo-user-command = "AUTHINFO" WS "USER" WS username
+   authinfo-pass-command = "AUTHINFO" WS "PASS" WS password
+
+   initial-response = base64-opt
+   username = 1*user-pass-char
+   password = 1*user-pass-char
+   user-pass-char = B-CHAR
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 16]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   NOTE: a server implementation MAY parse AUTHINFO USER and AUTHINFO
+   PASS specially so as to allow white space to be used within the
+   username or password.  Such implementations accept the additional
+   syntax (making these two items inconsistent with "token" in Section
+   9.8 of [NNTP]):
+
+   user-pass-char =/ SP / TAB
+
+   In doing so, the grammar can become ambiguous if the username or
+   password begins or ends with white space.  To solve this ambiguity,
+   such implementations typically treat everything after the first white
+   space character following "USER"/"PASS", up to, but not including,
+   the CRLF, as the username/password.
+
+3.2.  Command Continuation
+
+   This syntax extends the non-terminal "command-continuation", which
+   represents the further material sent by the client in the case of
+   multi-stage commands.
+
+   command-continuation =/ authinfo-sasl-383-continuation
+
+   authinfo-sasl-383-continuation = ("*" / base64-opt) CRLF
+
+3.3.  Responses
+
+   This syntax extends the non-terminal "initial-response-content",
+   which represents an initial response line sent by the server.
+
+   initial-response-content =/ response-283-content /
+        response-383-content
+
+   response-283-content = "283" SP base64
+   response-383-content = "383" SP base64-opt
+
+3.4.  Capability Entries
+
+   This syntax extends the non-terminal "capability-entry", which
+   represents a capability that may be advertised by the server.
+
+   capability-entry =/ authinfo-capability /
+        sasl-capability
+
+   authinfo-capability = "AUTHINFO" *(WS authinfo-variant)
+   authinfo-variant = "USER" / "SASL"
+   sasl-capability = "SASL" 1*(WS mechanism)
+
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 17]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+3.5.  General Non-terminals
+
+   base64-opt = "=" / base64
+   mechanism = 1*20mech-char
+   mech-char = UPPER / DIGIT / "-" / "_"
+
+4.  Summary of Response Codes
+
+   This section contains a list of each new response code defined in
+   this document and indicates whether it is multi-line, which commands
+   can generate it, what arguments it has, and what its meaning is.
+
+   Response code 281
+      Generated by: AUTHINFO USER, AUTHINFO PASS, AUTHINFO SASL
+      Meaning: authentication accepted
+
+   Response code 283
+      Generated by: AUTHINFO SASL
+      1 argument: challenge
+      Meaning: authentication accepted (with success data)
+
+   Response code 381
+      Generated by: AUTHINFO USER
+      Meaning: password required via AUTHINFO PASS command.  Note
+      that this code is used for backwards compatibility and does
+      not conform to the traditional use of 3xx codes.
+
+   Response code 383
+      Generated by: AUTHINFO SASL
+      1 argument: challenge
+      Meaning: continue with SASL exchange
+
+   Response code 481
+      Generated by: AUTHINFO USER, AUTHINFO PASS, AUTHINFO SASL
+      Meaning: authentication failed/rejected
+
+   Response code 482
+      Generated by: AUTHINFO USER, AUTHINFO PASS, AUTHINFO SASL
+      Meaning: authentication commands issued out of sequence or
+      SASL protocol error
+
+5.  Authentication Tracking/Logging
+
+   This section contains implementation suggestions and notes of best
+   current practice; it does not specify further network protocol
+   requirements.
+
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 18]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   Once authenticated, the authorization identity presented in the
+   AUTHINFO exchange (username when using USER/PASS) SHOULD be included
+   in an audit trail associating the identity with any articles supplied
+   during a POST operation, and this configuration SHOULD be the
+   default.  This may be accomplished, for example, by inserting headers
+   in the posted articles or by a server logging mechanism.  The server
+   MAY provide a facility for disabling the procedure described above,
+   as some users or administrators may consider it a violation of
+   privacy.
+
+6.  Security Considerations
+
+   Security issues are discussed throughout this memo.
+
+   In general, the security considerations of [SASL] and any implemented
+   SASL mechanisms are applicable here; only the most important are
+   highlighted specifically below.  Also, this extension is not intended
+   to cure the security considerations described in section 12 of
+   [NNTP]; those considerations remain relevant to any NNTP
+   implementation.
+
+   Before the [SASL] negotiation has begun, any protocol interactions
+   may have been performed in the clear and may have been modified by an
+   active attacker.  For this reason, clients and servers MUST discard
+   any sensitive knowledge obtained prior to the start of the SASL
+   negotiation upon the establishment of a security layer.  Furthermore,
+   the CAPABILITIES command SHOULD be re-issued upon the establishment
+   of a security layer, and other protocol state SHOULD be re-negotiated
+   as well.
+
+   Servers MAY implement a policy whereby the connection is dropped
+   after a number of failed authentication attempts.  If they do so,
+   they SHOULD NOT drop the connection until at least 3 attempts at
+   authentication have failed.
+
+   Implementations MUST support a configuration where authentication
+   mechanisms that are vulnerable to passive eavesdropping attacks (such
+   as AUTHINFO USER/PASS and SASL [PLAIN]) are not advertised or used
+   without the presence of an external security layer such as TLS
+   [NNTP-TLS], and this configuration SHOULD be the default.
+
+   When multiple authentication mechanisms are permitted by both client
+   and server, an active attacker can cause a down-negotiation to the
+   weakest mechanism.  For this reason, both clients and servers SHOULD
+   be configurable to forbid use of weak mechanisms.  The minimum
+   strength acceptable is a policy decision that is outside the scope of
+   this specification.
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 19]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+7.  IANA Considerations
+
+7.1.  IANA Considerations for SASL/GSSAPI Services
+
+   The IANA has registered the SASL/GSSAPI service name "nntp".  This
+   service name refers to authenticated use of Usenet news service when
+   it is provided via the [NNTP] protocol.
+
+   o  Published Specification: This document.
+
+   o  Contact for Further Information: Authors of this document.
+
+   o  Change Controller: IESG <iesg@ietf.org>.
+
+7.2.  IANA Considerations for NNTP Extensions
+
+   This section gives a formal definition of the AUTHINFO extension, as
+   required by Section 3.3.3 of [NNTP] for the IANA registry.
+
+   o  This extension provides an extensible mechanism for NNTP
+      authentication via a variety of methods.
+
+   o  The capability label for this extension is "AUTHINFO".
+
+   o  The "AUTHINFO" capability label has two possible optional
+      arguments, "USER" and "SASL" (as defined in Section 2.1),
+      indicating which variants of the AUTHINFO command are supported.
+
+   o  This extension also provides the "SASL" capability label, whose
+      arguments list the available SASL mechanisms.
+
+   o  This extension defines three new commands, AUTHINFO USER, AUTHINFO
+      PASS, and AUTHINFO SASL, whose behavior, arguments, and responses
+      are defined in Sections 2.3 and 2.4.
+
+   o  This extension does not associate any new responses with pre-
+      existing NNTP commands.
+
+   o  This extension may affect the overall behavior of both server and
+      client in that the AUTHINFO SASL command may require that
+      subsequent communication be transmitted via an intermediary
+      security layer.
+
+   o  The length of the AUTHINFO SASL command (as defined in this
+      document) may exceed 512 octets.  The maximum length of this
+      command is increased to that which can accommodate the largest
+      initial response possible for any of the SASL mechanisms supported
+      by the implementation.
+
+
+
+Vinocur, et al.             Standards Track                    [Page 20]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   o  This extension defines two new responses, 283 and 383, whose
+      lengths may exceed 512 octets.  The maximum length of these
+      responses is increased to that which can accommodate the largest
+      challenge possible for any of the SASL mechanisms supported by the
+      implementation.
+
+   o  This extension does not alter pipelining, but AUTHINFO commands
+      cannot be pipelined.
+
+   o  Use of this extension may alter the capabilities list; once the
+      AUTHINFO command has been used successfully, the AUTHINFO
+      capability can no longer be advertised by CAPABILITIES.
+      Additionally, the MODE-READER capability MUST NOT be advertised
+      after successful authentication.
+
+   o  This extension does not cause any pre-existing command to produce
+      a 401, 480, or 483 response.
+
+   o  This extension is unaffected by any use of the MODE READER
+      command; however, the MODE READER command MUST NOT be used in the
+      same session following successful authentication.
+
+   o  Published Specification: This document.
+
+   o  Contact for Further Information: Authors of this document.
+
+   o  Change Controller: IESG <iesg@ietf.org>.
+
+8.  Acknowledgements
+
+   This RFC originated from a document initially written by Chris
+   Newman.
+
+   A significant amount of the authentication text was originally from
+   the NNTP revision or common authentication specs written by Stan
+   Barber.  A significant amount of the SASL text was lifted from the
+   revisions to RFC 1734 and RFC 2554 by Rob Siemborski.
+
+   Special acknowledgement also goes to Russ Allbery, Clive Feather, and
+   others who commented privately on intermediate revisions of this
+   document, as well as the members of the IETF NNTP Working Group for
+   continual (yet sporadic) insight in discussion.
+
+
+
+
+
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 21]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+9.  References
+
+9.1.  Normative References
+
+   [ABNF]        Crocker, D., Ed. and P. Overell, "Augmented BNF for
+                 Syntax Specifications: ABNF", RFC 4234, October 2005.
+
+   [AUTH]        Haller, N. and R. Atkinson, "On Internet
+                 Authentication", RFC 1704, October 1994.
+
+   [BASE64]      Josefsson, S., "The Base16, Base32, and Base64 Data
+                 Encodings", RFC 4648, October 2006.
+
+   [DIGEST-MD5]  Leach, P. and C. Newman, "Using Digest Authentication
+                 as a SASL Mechanism", RFC 2831, May 2000.
+
+   [KEYWORDS]    Bradner, S., "Key words for use in RFCs to Indicate
+                 Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [NNTP]        Feather, C., "Network News Transfer Protocol (NNTP)",
+                 RFC 3977, October 2006.
+
+   [NNTP-TLS]    Murchison, K., Vinocur, J., and C. Newman, "Using
+                 Transport Layer Security (TLS) with Network News
+                 Transfer Protocol (NNTP)", RFC 4642, October 2006.
+
+   [SASL]        Melnikov, A. and K. Zeilenga, "Simple Authentication
+                 and Security Layer (SASL)", RFC 4422, June 2006.
+
+   [SASLprep]    Zeilenga, K., "SASLprep: Stringprep Profile for User
+                 Names and Passwords", RFC 4013, February 2005.
+
+   [StringPrep]  Hoffman, P. and M. Blanchet, "Preparation of
+                 Internationalized Strings ("stringprep")", RFC 3454,
+                 December 2002.
+
+9.2. Informative References
+
+   [BEEP]        Rose, M., "The Blocks Extensible Exchange Protocol
+                 Core", RFC 3080, March 2001.
+
+   [CRAM-MD5]    Nerenberg, L., "The CRAM-MD5 SASL Mechanism", Work in
+                 Progress.
+
+   [GSSAPI]      Melnikov, A., "SASL GSSAPI mechanisms", Work in
+                 Progress.
+
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 22]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+   [IMAP]        Crispin, M., "INTERNET MESSAGE ACCESS PROTOCOL -
+                 VERSION 4rev1", RFC 3501, March 2003.
+
+   [LDAP-AUTH]   Harrison, R., "Lightweight Directory Access Protocol
+                 (LDAP): Authentication Methods and Security
+                 Mechanisms", RFC 4513, June 2006.
+
+   [NNTP-COMMON] Barber, S., "Common NNTP Extensions", RFC 2980, October
+                 2000.
+
+   [PLAIN]       Zeilenga, K., Ed., "The PLAIN Simple Authentication and
+                 Security Layer (SASL) Mechanism", RFC 4616, August
+                 2006.
+
+   [POP-AUTH]    Myers, J., "POP3 AUTHentication command", RFC 1734,
+                 December 1994.
+
+   [SMTP-AUTH]   Myers, J., "SMTP Service Extension for Authentication",
+                 RFC 2554, March 1999.
+
+Authors' Addresses
+
+   Jeffrey M. Vinocur
+   Department of Computer Science
+   Upson Hall
+   Cornell University
+   Ithaca, NY 14853 USA
+
+   EMail: vinocur@cs.cornell.edu
+
+
+   Kenneth Murchison
+   Carnegie Mellon University
+   5000 Forbes Avenue
+   Cyert Hall 285
+   Pittsburgh, PA  15213 USA
+
+   EMail: murch@andrew.cmu.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 23]
+
+RFC 4643                  NNTP Authentication               October 2006
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Vinocur, et al.             Standards Track                    [Page 24]
+

--- a/doc/rfc4644.txt
+++ b/doc/rfc4644.txt
@@ -1,0 +1,787 @@
+
+
+
+
+
+
+Network Working Group                                         J. Vinocur
+Request for Comments: 4644                            Cornell University
+Updates: 2980                                               K. Murchison
+Category: Standards Track                     Carnegie Mellon University
+                                                            October 2006
+
+
+  Network News Transfer Protocol (NNTP) Extension for Streaming Feeds
+
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2006).
+
+Abstract
+
+   This memo defines an extension to the Network News Transfer Protocol
+   (NNTP) to provide asynchronous (otherwise known as "streaming")
+   transfer of articles.  This allows servers to transfer articles to
+   other servers with much greater efficiency.
+
+   This document updates and formalizes the CHECK and TAKETHIS commands
+   specified in RFC 2980 and deprecates the MODE STREAM command.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+      1.1. Conventions Used in this Document ..........................2
+   2. The STREAMING Extension .........................................3
+      2.1. Streaming Article Transfer .................................3
+      2.2. Advertising the STREAMING Extension ........................4
+      2.3. MODE STREAM Command ........................................5
+           2.3.1. Usage ...............................................5
+           2.3.2. Description .........................................5
+           2.3.3. Examples ............................................5
+      2.4. CHECK Command ..............................................6
+           2.4.1. Usage ...............................................6
+           2.4.2. Description .........................................6
+           2.4.3. Examples ............................................6
+      2.5. TAKETHIS Command ...........................................7
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 1]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+           2.5.1. Usage ...............................................7
+           2.5.2. Description .........................................7
+           2.5.3. Examples ............................................8
+   3. Augmented BNF Syntax for the STREAMING Extension ................9
+      3.1. Commands ...................................................9
+      3.2. Command Datastream .........................................9
+      3.3. Responses .................................................10
+      3.4. Capability Entries ........................................10
+   4. Summary of Response Codes ......................................10
+   5. Security Considerations ........................................11
+   6. IANA Considerations ............................................11
+   7. Acknowledgements ...............................................12
+   8. References .....................................................12
+      8.1. Normative References ......................................12
+      8.2. Informative References ....................................12
+
+1.  Introduction
+
+   According to the NNTP specification [NNTP], a peer uses the IHAVE
+   command to query whether a server wants a particular article.
+   Because the IHAVE command cannot be pipelined, the need to stop and
+   wait for the remote end's response greatly restricts the throughput
+   that can be achieved.
+
+   The ad-hoc CHECK and TAKETHIS commands, originally documented in
+   [NNTP-COMMON], provide an alternative method of peer-to-peer article
+   transfer that permits a more effective use of network bandwidth.  Due
+   to their proven usefulness and wide deployment, they are formalized
+   in this specification.
+
+   The ad-hoc MODE STREAM command, also documented in [NNTP-COMMON], is
+   deprecated by this specification, but due to its ubiquity is
+   documented here for backwards compatibility.
+
+1.1.  Conventions Used in this Document
+
+   The notational conventions used in this document are the same as
+   those in [NNTP] and any term not defined in this document has the
+   same meaning as in that one.
+
+   The key words "REQUIRED", "MUST", "MUST NOT", "SHOULD", "SHOULD NOT",
+   "MAY", and "OPTIONAL" in this document are to be interpreted as
+   described in "Key words for use in RFCs to Indicate Requirement
+   Levels" [KEYWORDS].
+
+
+
+
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 2]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+   This document assumes you familiarity with NNTP [NNTP].  In general,
+   the connections described below are from one peer to another, but we
+   will continue to use "client" to mean the initiator of the NNTP
+   connection, and "server" to mean the other endpoint.
+
+   In the examples, commands from the client are indicated with [C], and
+   responses from the server are indicated with [S].
+
+2.  The STREAMING Extension
+
+   This extension provides three new commands: MODE STREAM, CHECK, and
+   TAKETHIS.  The capability label for this extension is STREAMING.
+
+2.1.  Streaming Article Transfer
+
+   The STREAMING extension provides the same functionality as the IHAVE
+   command ([NNTP] section 6.3.2) but splits the query and transfer
+   functionality into the CHECK and TAKETHIS commands respectively.
+   This allows the CHECK and TAKETHIS commands to be pipelined ([NNTP]
+   section 3.5) and provides for "streaming" article transfer.
+
+   A streaming client will often pipeline many CHECK commands and use
+   the responses to construct a list of articles to be sent by a
+   pipelined sequence of TAKETHIS commands, thus increasing the fraction
+   of time spent transferring articles.  The CHECK and TAKETHIS commands
+   utilize distinct response codes so that these commands can be
+   intermingled in a pipeline and the response to any single command can
+   be definitively identified by the client.
+
+   The client MAY send articles via TAKETHIS without first querying the
+   server with CHECK.  The client SHOULD NOT send every article in this
+   fashion unless explicitly configured to do so by the site
+   administrator based on out-of-band information.  However, the client
+   MAY use an adaptive strategy where it initially sends CHECK commands
+   for all articles, but switches to using TAKETHIS without CHECK if
+   most articles are being accepted (over 95% acceptance might be a
+   reasonable metric in some configurations).  If the client uses such a
+   strategy, it SHOULD also switch back to using CHECK on all articles
+   if the acceptance rate ever falls much below the threshold.
+
+
+
+
+
+
+
+
+
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 3]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+2.2.  Advertising the STREAMING Extension
+
+   A server supporting the streaming commands described in this document
+   will advertise the "STREAMING" capability label in response to the
+   CAPABILITIES command ([NNTP] section 5.2).  The server MUST continue
+   to advertise this capability after a client has issued the MODE
+   STREAM command.  This capability MAY be advertised both before and
+   after any use of the MODE READER command ([NNTP] section 5.3), with
+   the same semantics.
+
+   Example of a client using CAPABILITIES and MODE STREAM on a mode-
+   switching server:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] MODE-READER
+      [S] IHAVE
+      [S] LIST ACTIVE
+      [S] STREAMING
+      [S] .
+      [C] MODE STREAM
+      [S] 203 Streaming permitted
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] MODE-READER
+      [S] IHAVE
+      [S] LIST ACTIVE
+      [S] STREAMING
+      [S] .
+      [C] MODE READER
+      [S] 200 Posting allowed
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] POST
+      [S] LIST ACTIVE NEWSGROUPS HEADERS
+      [S] HDR
+      [S] .
+
+
+
+
+
+
+
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 4]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+2.3.  MODE STREAM Command
+
+   Historically this command was used by a client to discover if a
+   server supported the CHECK and TAKETHIS commands.  This command is
+   deprecated in favor of the CAPABILITIES discovery command and is only
+   provided here for compatibility with legacy implementations
+   [NNTP-COMMON] of these transport commands.
+
+   New clients SHOULD use the CAPABILITIES command to check a server for
+   support of the STREAMING extension but MAY use the MODE STREAM
+   command for backwards compatibility with legacy servers that don't
+   support the CAPABILITIES discovery command.  Servers MUST accept the
+   MODE STREAM command for backwards compatibility with legacy clients
+   that don't use the CAPABILITIES discovery command.
+
+   NOTE: This command may be removed from a future version of this
+   specification, therefore clients are urged to transition to the
+   CAPABILITIES command wherever possible.
+
+2.3.1.  Usage
+
+   Syntax
+      MODE STREAM
+
+   Responses
+      203   Streaming permitted
+
+2.3.2.  Description
+
+   If a server supports this extension, it MUST return a 203 response to
+   the MODE STREAM command (or 501 if an argument is given).  The MODE
+   STREAM command MUST NOT affect the server state in any way (that is,
+   it is not a mode change despite the name), therefore this command MAY
+   be pipelined.  A server MUST NOT require that the MODE STREAM command
+   be issued by the client before accepting the CHECK or TAKETHIS
+   commands.
+
+2.3.3.  Examples
+
+   Example of a client checking the ability to stream articles on a
+   server which does not support this extension:
+
+      [C] MODE STREAM
+      [S] 501 Unknown MODE variant
+
+   Example of a client checking the ability to stream articles on a
+   server which supports this extension:
+
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 5]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+      [C] MODE STREAM
+      [S] 203 Streaming permitted
+
+2.4.  CHECK Command
+
+2.4.1.  Usage
+
+   Syntax
+      CHECK message-id
+
+   Responses
+      238 message-id   Send article to be transferred
+      431 message-id   Transfer not possible; try again later
+      438 message-id   Article not wanted
+
+   Parameters
+      message-id = Article message-id
+
+   The first parameter of the 238, 431, and 438 responses MUST be the
+   message-id provided by the client as the parameter to CHECK.
+
+2.4.2.  Description
+
+   The CHECK command informs the server that the client has an article
+   with the specified message-id.  If the server desires a copy of that
+   article, a 238 response MUST be returned, indicating that the client
+   may send the article using the TAKETHIS command.  If the server does
+   not want the article (if, for example, the server already has a copy
+   of it), a 438 response MUST be returned, indicating that the article
+   is not wanted.  Finally, if the article isn't wanted immediately but
+   the client should retry later if possible (if, for example, another
+   client has offered to send the same article to the server), a 431
+   response MUST be returned.
+
+   NOTE: The responses to CHECK are advisory; the server MUST NOT rely
+   on the client to behave as requested by these responses.
+
+2.4.3.  Examples
+
+   Example of a client checking whether the server would like a set of
+   articles and getting a mixture of responses:
+
+      [C] CHECK <i.am.an.article.you.will.want@example.com>
+      [S] 238 <i.am.an.article.you.will.want@example.com>
+      [C] CHECK <i.am.an.article.you.have@example.com>
+      [S] 438 <i.am.an.article.you.have@example.com>
+      [C] CHECK <i.am.an.article.you.defer@example.com>
+      [S] 431 <i.am.an.article.you.defer@example.com>
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 6]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+   Example of pipelining the CHECK commands in the previous example:
+
+      [C] CHECK <i.am.an.article.you.will.want@example.com>
+      [C] CHECK <i.am.an.article.you.have@example.com>
+      [C] CHECK <i.am.an.article.you.defer@example.com>
+      [S] 238 <i.am.an.article.you.will.want@example.com>
+      [S] 438 <i.am.an.article.you.have@example.com>
+      [S] 431 <i.am.an.article.you.defer@example.com>
+
+2.5.  TAKETHIS Command
+
+2.5.1.  Usage
+
+   A client MUST NOT use this command unless the server advertises the
+   STREAMING capability or returns a 203 response to the MODE STREAM
+   command.
+
+   Syntax
+      TAKETHIS message-id
+
+   Responses
+      239 message-id   Article transferred OK
+      439 message-id   Transfer rejected; do not retry
+
+   Parameters
+      message-id = Article message-id
+
+   The first parameter of the 239 and 439 responses MUST be the
+   message-id provided by the client as the parameter to TAKETHIS.
+
+2.5.2.  Description
+
+   The TAKETHIS command is used to send an article with the specified
+   message-id to the server.  The article is sent immediately following
+   the CRLF at the end of the TAKETHIS command line.  The client MUST
+   send the entire article, including headers and body, to the server as
+   a multi-line data block ([NNTP] section 3.1.1).  Thus, a single dot
+   (".") on a line indicates the end of the text, and lines starting
+   with a dot in the original text have that dot doubled during
+   transmission.  The server MUST return either a 239 response,
+   indicating that the article was successfully transferred, or a 439
+   response, indicating that the article was rejected.  If the server
+   encounters a temporary error that prevents it from processing the
+   article but does not want to reject the article, it MUST reply with a
+   400 response to the client and close the connection.
+
+   This function differs from the POST command in that it is intended
+   for use in transferring already-posted articles between hosts.  It
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 7]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+   SHOULD NOT be used when the client is a personal news-reading
+   program, since use of this command indicates that the article has
+   already been posted at another site and is simply being forwarded
+   from another host.  However, despite this, the server MAY elect not
+   to post or forward the article if, after further examination of the
+   article, it deems it inappropriate to do so.  Reasons for such
+   subsequent rejection of an article may include problems such as
+   inappropriate newsgroups or distributions, disk space limitations,
+   article lengths, garbled headers, and the like.  These are typically
+   restrictions enforced by the server host's news software and not
+   necessarily by the NNTP server itself.
+
+   The client SHOULD NOT assume that the article has been successfully
+   transferred unless it receives an affirmative response from the
+   server.  A lack of response (such as a dropped network connection or
+   a network timeout) or a 400 response SHOULD be treated as a temporary
+   failure and cause the transfer to be tried again later if possible.
+
+   Because some news server software may not immediately be able to
+   determine whether an article is suitable for posting or forwarding,
+   an NNTP server MAY acknowledge the successful transfer of the article
+   (with a 239 response) but later silently discard it.
+
+2.5.3.  Examples
+
+   Example of streaming two articles to another site (the first article
+   is accepted and the second is rejected):
+
+      [C] TAKETHIS <i.am.an.article.you.will.want@example.com>
+      [C] Path: pathost!demo!somewhere!not-for-mail
+      [C] From: "Demo User" <nobody@example.com>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Date: 6 Oct 1998 04:38:40 -0500
+      [C] Organization: An Example Com, San Jose, CA
+      [C] Message-ID: <i.am.an.article.you.will.want@example.com>
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [C] TAKETHIS <i.am.an.article.you.have@example.com>
+      [C] Path: pathost!demo!somewhere!not-for-mail
+      [C] From: "Demo User" <nobody@example.com>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Date: 6 Oct 1998 04:38:40 -0500
+      [C] Organization: An Example Com, San Jose, CA
+      [C] Message-ID: <i.am.an.article.you.have@example.com>
+      [C]
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 8]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+      [C] This is just a test article.
+      [C] .
+      [S] 239 <i.am.an.article.you.will.want@example.com>
+      [S] 439 <i.am.an.article.you.have@example.com>
+
+   Example of sending an article to a site where the transfer fails:
+
+      [C] TAKETHIS <i.am.an.article.you.will.want@example.com>
+      [C] Path: pathost!demo!somewhere!not-for-mail
+      [C] From: "Demo User" <nobody@example.com>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Date: 6 Oct 1998 04:38:40 -0500
+      [C] Organization: An Example Com, San Jose, CA
+      [C] Message-ID: <i.am.an.article.you.will.want@example.com>
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [S] 400 Service temporarily unavailable
+      [Server closes connection.]
+
+3.  Augmented BNF Syntax for the STREAMING Extension
+
+   This section describes the formal syntax of the STREAMING extension
+   using ABNF [ABNF].  It extends the syntax in section 9 of [NNTP], and
+   non-terminals not defined in this document are defined there.  The
+   [NNTP] ABNF should be imported first before attempting to validate
+   these rules.
+
+3.1.  Commands
+
+   This syntax extends the non-terminal "command", which represents an
+   NNTP command.
+
+   command =/ check-command /
+        mode-stream-command /
+        takethis-command
+
+   check-command       = "CHECK" WS message-id
+   mode-stream-command = "MODE" WS "STREAM"
+   takethis-command    = "TAKETHIS" WS message-id
+
+3.2.  Command Datastream
+
+   This syntax extends the non-terminal "command-datastream", which
+   represents the further material sent by the client in the case of
+   streaming commands.
+
+
+
+
+Vinocur & Murchison         Standards Track                     [Page 9]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+   command-datastream =/ takethis-datastream
+
+   takethis-datastream = encoded-article
+
+3.3.  Responses
+
+   This syntax extends the non-terminal "initial-response-content",
+   which represents an initial response line sent by the server.
+
+   initial-response-content =/ response-238-content /
+        response-239-content /
+        response-431-content /
+        response-438-content /
+        response-439-content
+
+   response-238-content = "238" SP message-id
+   response-239-content = "239" SP message-id
+   response-431-content = "431" SP message-id
+   response-438-content = "438" SP message-id
+   response-439-content = "439" SP message-id
+
+3.4.  Capability Entries
+
+   This syntax extends the non-terminal "capability-entry", which
+   represents a capability that may be advertised by the server.
+
+   capability-entry =/ streaming-capability
+
+   streaming-capability = "STREAMING"
+
+4.  Summary of Response Codes
+
+   This section contains a list of each new response code defined in
+   this document and indicates whether it is multi-line, which commands
+   can generate it, what arguments it has, and what its meaning is.
+
+   Response code 203
+      Generated by: MODE STREAM
+      Meaning: streaming permitted.
+
+   Response code 238
+      Generated by: CHECK
+      1 argument: message-id
+      Meaning: send article to be transferred.
+
+
+
+
+
+
+
+Vinocur & Murchison         Standards Track                    [Page 10]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+   Response code 239
+      Generated by: TAKETHIS
+      1 argument: message-id
+      Meaning: article transferred OK.
+
+   Response code 431
+      Generated by: CHECK
+      1 argument: message-id
+      Meaning: transfer not possible; try again later.
+
+   Response code 438
+      Generated by: CHECK
+      1 argument: message-id
+      Meaning: article not wanted.
+
+   Response code 439
+      Generated by: TAKETHIS
+      1 argument: message-id
+      Meaning: transfer rejected; do not retry.
+
+5.  Security Considerations
+
+   No new security considerations are introduced by this extension,
+   beyond those already described in the core specification [NNTP].
+
+6.  IANA Considerations
+
+   This section gives a formal definition of the STREAMING extension as
+   required by Section 3.3.3 of [NNTP] for the IANA registry.
+
+   o  The STREAMING extension provides for streaming transfer of
+      articles.
+
+   o  The capability label for this extension is "STREAMING".
+
+   o  The capability label has no arguments.
+
+   o  The extension defines three new commands, MODE STREAM, CHECK, and
+      TAKETHIS, whose behavior, arguments, and responses are defined in
+      Sections 2.3, 2.4, and 2.5 respectively.
+
+   o  The extension does not associate any new responses with pre-
+      existing NNTP commands.
+
+   o  The extension does not affect the behavior of a server or client
+      other than via the new commands.
+
+
+
+
+
+Vinocur & Murchison         Standards Track                    [Page 11]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+   o  The extension does not affect the maximum length of commands or
+      initial response lines.
+
+   o  The extension does not alter pipelining, and the MODE STREAM,
+      CHECK, and TAKETHIS commands can be pipelined.
+
+   o  Use of this extension does not alter the capabilities list.
+
+   o  The extension does not cause any pre-existing command to produce a
+      401, 480, or 483 response.
+
+   o  Use of the MODE READER command on a mode-switching server may
+      disable this extension.
+
+   o  Published Specification: This document.
+
+   o  Contact for Further Information: Authors of this document.
+
+   o  Change Controller: IESG <iesg@ietf.org>.
+
+7.  Acknowledgements
+
+   This document is based heavily on the relevant sections of RFC 2980
+   [NNTP-COMMON], by Stan Barber.
+
+   Special acknowledgement also goes to Russ Allbery, Clive Feather,
+   Andrew Gierth, and others who commented privately on intermediate
+   revisions of this document, as well as the members of the IETF NNTP
+   Working Group for continual (yet sporadic) insight in discussion.
+
+8.  References
+
+8.1.  Normative References
+
+   [ABNF]        Crocker, D., Ed. and P. Overell, "Augmented BNF for
+                 Syntax Specifications: ABNF", RFC 4234, October 2005.
+
+   [KEYWORDS]    Bradner, S., "Key words for use in RFCs to Indicate
+                 Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [NNTP]        Feather, C., "Network News Transfer Protocol (NNTP)",
+                 RFC 3977, October 2006.
+
+8.2.  Informative References
+
+   [NNTP-COMMON] Barber, S., "Common NNTP Extensions", RFC 2980, October
+                 2000.
+
+
+
+
+Vinocur & Murchison         Standards Track                    [Page 12]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+Authors' Addresses
+
+   Jeffrey M. Vinocur
+   Department of Computer Science
+   Upson Hall
+   Cornell University
+   Ithaca, NY  14853
+
+   EMail: vinocur@cs.cornell.edu
+
+
+   Kenneth Murchison
+   Carnegie Mellon University
+   5000 Forbes Avenue
+   Cyert Hall 285
+   Pittsburgh, PA  15213 USA
+
+   EMail: murch@andrew.cmu.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Vinocur & Murchison         Standards Track                    [Page 13]
+
+RFC 4644           NNTP Extension for Streaming Feeds       October 2006
+
+
+Full Copyright Statement
+
+Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is provided by the IETF
+   Administrative Support Activity (IASA).
+
+
+
+
+
+
+
+Vinocur & Murchison         Standards Track                    [Page 14]
+

--- a/doc/rfc6048.txt
+++ b/doc/rfc6048.txt
@@ -1,0 +1,1403 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                           J. Elie
+Request for Comments: 6048                                 November 2010
+Updates: 2980, 3977
+Category: Standards Track
+ISSN: 2070-1721
+
+
+    Network News Transfer Protocol (NNTP) Additions to LIST Command
+
+Abstract
+
+   This document defines a set of enhancements to the Network News
+   Transfer Protocol (NNTP) that allow a client to request extended
+   information from NNTP servers regarding server status, policy, and
+   other aspects of local configuration.  These enhancements are made as
+   new keywords to the existing LIST capability described in RFC 3977.
+
+   This memo updates and formalizes the LIST DISTRIBUTIONS and LIST
+   SUBSCRIPTIONS commands defined in RFC 2980.  It also adds the LIST
+   COUNTS, LIST MODERATORS, and LIST MOTD commands, and specifies
+   additional values returned by the existing LIST ACTIVE command for
+   the status of a newsgroup.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6048.
+
+Copyright Notice
+
+   Copyright (c) 2010 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+
+
+
+Elie                         Standards Track                    [Page 1]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  3
+     1.1.  Conventions Used in This Document  . . . . . . . . . . . .  4
+     1.2.  Author's Note  . . . . . . . . . . . . . . . . . . . . . .  4
+   2.  New LIST Variants  . . . . . . . . . . . . . . . . . . . . . .  4
+     2.1.  Advertising the New LIST Variants  . . . . . . . . . . . .  4
+     2.2.  LIST COUNTS  . . . . . . . . . . . . . . . . . . . . . . .  5
+       2.2.1.  Usage  . . . . . . . . . . . . . . . . . . . . . . . .  5
+       2.2.2.  Description  . . . . . . . . . . . . . . . . . . . . .  6
+       2.2.3.  Examples . . . . . . . . . . . . . . . . . . . . . . .  7
+     2.3.  LIST DISTRIBUTIONS . . . . . . . . . . . . . . . . . . . .  8
+       2.3.1.  Usage  . . . . . . . . . . . . . . . . . . . . . . . .  8
+       2.3.2.  Description  . . . . . . . . . . . . . . . . . . . . .  8
+       2.3.3.  Example  . . . . . . . . . . . . . . . . . . . . . . . 10
+     2.4.  LIST MODERATORS  . . . . . . . . . . . . . . . . . . . . . 10
+       2.4.1.  Usage  . . . . . . . . . . . . . . . . . . . . . . . . 10
+       2.4.2.  Description  . . . . . . . . . . . . . . . . . . . . . 10
+       2.4.3.  Example  . . . . . . . . . . . . . . . . . . . . . . . 12
+     2.5.  LIST MOTD  . . . . . . . . . . . . . . . . . . . . . . . . 13
+       2.5.1.  Usage  . . . . . . . . . . . . . . . . . . . . . . . . 13
+       2.5.2.  Description  . . . . . . . . . . . . . . . . . . . . . 13
+       2.5.3.  Example  . . . . . . . . . . . . . . . . . . . . . . . 14
+     2.6.  LIST SUBSCRIPTIONS . . . . . . . . . . . . . . . . . . . . 14
+       2.6.1.  Usage  . . . . . . . . . . . . . . . . . . . . . . . . 14
+       2.6.2.  Description  . . . . . . . . . . . . . . . . . . . . . 15
+       2.6.3.  Examples . . . . . . . . . . . . . . . . . . . . . . . 16
+   3.  Additions to LIST ACTIVE . . . . . . . . . . . . . . . . . . . 16
+     3.1.  New Status Field Values  . . . . . . . . . . . . . . . . . 16
+     3.2.  Examples . . . . . . . . . . . . . . . . . . . . . . . . . 20
+   4.  Augmented BNF Syntax for These Additions to the LIST
+       Command  . . . . . . . . . . . . . . . . . . . . . . . . . . . 21
+     4.1.  Commands . . . . . . . . . . . . . . . . . . . . . . . . . 21
+     4.2.  Responses  . . . . . . . . . . . . . . . . . . . . . . . . 21
+   5.  Internationalization Considerations  . . . . . . . . . . . . . 22
+   6.  Security Considerations  . . . . . . . . . . . . . . . . . . . 23
+   7.  IANA Considerations  . . . . . . . . . . . . . . . . . . . . . 23
+   8.  Acknowledgements . . . . . . . . . . . . . . . . . . . . . . . 24
+   9.  References . . . . . . . . . . . . . . . . . . . . . . . . . . 24
+     9.1.  Normative References . . . . . . . . . . . . . . . . . . . 24
+     9.2.  Informative References . . . . . . . . . . . . . . . . . . 25
+
+
+
+
+
+
+Elie                         Standards Track                    [Page 2]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+1.  Introduction
+
+   The NNTP specification [RFC3977] defines the LIST capability and a
+   few keywords that can be used with that command: ACTIVE,
+   ACTIVE.TIMES, DISTRIB.PATS, HEADERS, NEWSGROUPS, and OVERVIEW.FMT.
+   Other variants of the LIST command are in use, but with limited or
+   absent documentation.  These variants are formalized in this
+   document.
+
+   The DISTRIBUTIONS and SUBSCRIPTIONS variants were originally
+   documented in [RFC2980].  The LIST DISTRIBUTIONS command is sent by a
+   news client to obtain a list of relevant distributions known by a
+   news server along with their descriptions.  The LIST SUBSCRIPTIONS
+   command is sent by a news client when first connecting to a news
+   server so as to obtain a list of recommended newsgroups available on
+   it.  Both of these commands are intended to be used in place of hard-
+   coding news clients to use specific distributions or look for
+   specific default newsgroups.
+
+   The MOTD variant was originally documented in [NNTP_LIST] (which also
+   describes the SUBSCRIPTIONS variant).  The LIST MOTD command is sent
+   by a news client to obtain a "message of the day" from the server
+   administrator regarding the current state of a news server.
+
+   The COUNTS and MODERATORS variants have not been documented before.
+   The LIST COUNTS command is similar to LIST ACTIVE, except that it
+   also returns an estimated number of articles in each newsgroup.  The
+   LIST MODERATORS command is sent by a news client to obtain a list of
+   associations between a moderated newsgroup and its submission address
+   template.
+
+   The ACTIVE variant was formalized in [RFC3977], but the meanings of
+   only three status field values in LIST ACTIVE responses have been
+   specified: "y", "n", and "m".  These statuses are particularly useful
+   for readers, since they describe local posting rights.  However,
+   several other statuses are in use that are primarily useful for peers
+   as they mainly describe how remote articles coming from peers are
+   locally handled by a given news server.  This memo defines three
+   other values for the status field in LIST ACTIVE responses: "x", "j",
+   and "=" followed by the name of a newsgroup.
+
+   This specification should be read in conjunction with the NNTP base
+   specification [RFC3977].  In the case of a conflict between these two
+   documents, [RFC3977] takes precedence.
+
+
+
+
+
+
+
+Elie                         Standards Track                    [Page 3]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+1.1.  Conventions Used in This Document
+
+   The notational conventions used in this document are the same as
+   those in [RFC3977], and any term not defined in this document has the
+   same meaning as it does in that one.
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+   When a hexadecimal correspondence is given to an octet in this
+   document, the value is in US-ASCII [ASCII] (for instance, ".", noted
+   %x2E).
+
+   In the examples, commands from the client are indicated with [C], and
+   responses from the server are indicated with [S].  The client is the
+   initiator of the NNTP connection; the server is the other endpoint.
+
+1.2.  Author's Note
+
+   Please write the first letter of "Elie" with an acute accent wherever
+   possible -- it is U+00C9, that is to say "&#201;" in XML.
+
+2.  New LIST Variants
+
+   The LIST capability is defined in Section 7.6 of [RFC3977].  It
+   allows the server to provide useful information to the client in
+   multi-line blocks.
+
+   This document provides five new keywords to the LIST capability:
+   COUNTS, DISTRIBUTIONS, MODERATORS, MOTD, and SUBSCRIPTIONS.
+
+   Each keyword is OPTIONAL and corresponds to the same-named variant of
+   the LIST command.
+
+2.1.  Advertising the New LIST Variants
+
+   When a news server implements a variant of the LIST command as
+   described in this specification, it advertises the corresponding
+   feature in the LIST capability.  Where one of these new LIST keywords
+   is advertised, it MUST have the meaning given in this specification.
+
+   For instance, if a news server implements the SUBSCRIPTIONS variant,
+   it will add the SUBSCRIPTIONS keyword to the LIST capability in
+   response to the CAPABILITIES command (see Section 5.2 of [RFC3977]):
+
+
+
+
+
+
+Elie                         Standards Track                    [Page 4]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] LIST ACTIVE NEWSGROUPS SUBSCRIPTIONS
+      [S] .
+      [C] LIST SUBSCRIPTIONS
+      [S] 215 List of recommended newsgroups follows
+      [S] local.welcome
+      [S] local.test
+      [S] news.newusers.questions
+      [S] news.announce.newusers
+      [S] .
+
+   For each of the new LIST variants described in this specification, an
+   empty response can be sent to the client:
+
+      [C] LIST SUBSCRIPTIONS
+      [S] 215 List of recommended newsgroups follows
+      [S] .
+
+   This means that the information is maintained by the news server but
+   that it is voluntarily empty.  Frequently, the news server maintains
+   the information in a configuration file.  This file can be empty or
+   contain only commented or blank lines, indicating a voluntary absence
+   of information.
+
+   When the news server software implements one of these LIST variants
+   but a particular server does not maintain the information (for
+   instance, when the configuration file does not exist), the 503
+   response code MUST be returned:
+
+      [C] LIST SUBSCRIPTIONS
+      [S] 503 No list of recommended newsgroups available
+
+2.2.  LIST COUNTS
+
+2.2.1.  Usage
+
+   Syntax
+      LIST COUNTS [wildmat]
+
+   Responses
+      215    List of newsgroups follows (multi-line)
+
+   Parameters
+      wildmat    Groups of interest
+
+
+
+
+Elie                         Standards Track                    [Page 5]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+2.2.2.  Description
+
+   See Section 7.6.1 of [RFC3977] for general requirements of the LIST
+   command.
+
+   The LIST COUNTS command returns a list of valid newsgroups carried by
+   the news server along with associated information, the "counts list",
+   and is similar to LIST ACTIVE.
+
+   The information is returned as a multi-line data block following the
+   215 response code and contains one line per newsgroup.  Each line of
+   this list MUST consist of five fields separated from each other by
+   one or more spaces (the usual practice is a single space) in the
+   following order:
+
+   o  The name of the newsgroup.
+
+   o  The reported high water mark for the group.
+
+   o  The reported low water mark for the group.
+
+   o  The estimated number of articles in the group.
+
+   o  The current status of the group on this server.
+
+   The reported high and low water marks, and the estimated number of
+   articles, are as described in the GROUP command (see Section 6.1.1 of
+   [RFC3977]), but note that they are in the opposite order to the 211
+   response (that is, number low high group) to the GROUP command.  The
+   current status of the group is as described in the LIST ACTIVE
+   command (see Section 7.6.3 of [RFC3977], as well as Section 3 of this
+   document).  Also note that, similarly to the LIST ACTIVE command, TAB
+   characters are not valid separators for the LIST COUNTS command.
+
+   The order of newsgroups in the counts list is not significant.  The
+   server need not consistently return the same order or the same
+   results if this command is used more than once in a session.
+
+   The same newsgroup SHOULD NOT appear twice in the output of this
+   command.
+
+   The counts list is newsgroup-based, and a wildmat MAY be specified,
+   in which case the response is limited to only the groups, if any,
+   whose names match the wildmat.  If no wildmat is specified, the
+   server MUST include every newsgroup that the client is permitted to
+   select with the GROUP command (see Section 6.1.1 of [RFC3977]).
+
+
+
+
+
+Elie                         Standards Track                    [Page 6]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   The counts list MAY be empty.  If the server does not maintain the
+   information, a 503 response code MUST be returned.  (However, note
+   that a news server that supports this command usually maintains the
+   information.)
+
+   The client MAY use LIST COUNTS in order to obtain an estimate of the
+   number of articles in every newsgroup the server carries, which
+   enables it to provide the end user with this information.  This
+   provides a simpler mechanism for a client to obtain the estimated
+   number of articles in newsgroups, compared with a sequence of
+   individual GROUP commands.
+
+2.2.3.  Examples
+
+   Example of output with no argument:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] LIST ACTIVE COUNTS NEWSGROUPS
+      [S] .
+      [C] LIST COUNTS
+      [S] 215 List of newsgroups follows
+      [S] misc.test 3002322 3000234 1234 y
+      [S] comp.risks 442001 441099 742 m
+      [S] rec.food.drink.tea 100 51 3 y
+      [S] local.empty 7 8 0 y
+      [S] local.tea 2004 1504 301 y
+      [S] .
+
+   Example of output with a wildmat:
+
+      [C] LIST COUNTS *.tea,misc.*,!local.*
+      [S] 215 List of newsgroups follows
+      [S] misc.test 3002322 3000234 1234 y
+      [S] rec.food.drink.tea 100 51 3 y
+      [S] .
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elie                         Standards Track                    [Page 7]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   Example of output on an implementation that includes leading zeroes:
+
+      [C] LIST COUNTS
+      [S] 215 List of newsgroups follows
+      [S] misc.test 0003002322 0003000234 1234 y
+      [S] comp.risks 0000442001 0000441099 742 m
+      [S] rec.food.drink.tea 0000000100 0000000051 3 y
+      [S] local.empty 0000000007 0000000008 0 y
+      [S] local.tea 0000002004 0000001504 301 y
+      [S] .
+
+   The estimated number of articles usually does not start with leading
+   zeroes, but MAY start with such zeroes.
+
+2.3.  LIST DISTRIBUTIONS
+
+2.3.1.  Usage
+
+   Syntax
+      LIST DISTRIBUTIONS
+
+   Responses
+      215    Distributions list follows (multi-line)
+
+2.3.2.  Description
+
+   See Section 7.6.1 of [RFC3977] for general requirements of the LIST
+   command.
+
+   A "distributions list" is maintained by some NNTP servers to contain
+   the name of each distribution that is known by the news server and a
+   short description about the meaning of the distribution.
+   Distributions are used by clients as potential values for the
+   Distribution header field body of a news article being posted (see
+   Section 3.2.4 of [RFC5536] for the definition of this header field).
+
+   The information is returned as a multi-line data block following the
+   215 response code and contains one line per distribution.  Each line
+   of this list MUST consist of two fields separated from each other by
+   one or more space or TAB characters (the usual practice is a single
+   TAB).  The first field is the name of the distribution, and the
+   second field is a short description of the distribution.  There are
+   no leading or trailing whitespaces in a line.  The description MAY
+   contain whitespaces.
+
+
+
+
+
+
+
+Elie                         Standards Track                    [Page 8]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   The order of distributions in the distributions list is not
+   significant; the server need not consistently return the same order
+   or the same results if this command is used more than once in a
+   session.
+
+   The same distribution SHOULD NOT appear twice in the output of this
+   command.
+
+   The description MUST be in UTF-8 [RFC3629].
+
+   The distributions list is not newsgroup-based, and an argument MUST
+   NOT be specified.  Otherwise, a 501 response code MUST be returned.
+
+   The distributions list MAY be empty.  If the server does not maintain
+   the information, a 503 response code MUST be returned.
+
+   The client MAY use this information to generate or supplement a list
+   of known distributions provided to the user.  If the news server
+   implements the LIST DISTRIBUTIONS command, it SHOULD also implement
+   the LIST DISTRIB.PATS command (defined in Section 7.6.5 of [RFC3977])
+   and describe in the distributions list all the distributions present
+   in the distrib.pats list so that the client can use both of these
+   commands jointly (naturally, the distributions list can also describe
+   distributions that are not present in the distrib.pats list).  Note
+   that the two commands need not return distributions in the same
+   order.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Elie                         Standards Track                    [Page 9]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+2.3.3.  Example
+
+   Example of a joint use of LIST DISTRIB.PATS and LIST DISTRIBUTIONS:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] LIST ACTIVE DISTRIB.PATS DISTRIBUTIONS NEWSGROUPS
+      [S] .
+      [C] LIST DISTRIB.PATS
+      [S] 215 Information follows
+      [S] 10:local.*:local
+      [S] 5:france.*:fr
+      [S] 20:local.here.*:thissite
+      [S] .
+      [C] LIST DISTRIBUTIONS
+      [S] 215 List of distributions follows
+      [S] fr Local to France.
+      [S] local Local to this news server.
+      [S] thissite Local to this site.
+      [S] usa Local to the United States of America.
+      [S] .
+
+2.4.  LIST MODERATORS
+
+2.4.1.  Usage
+
+   Syntax
+      LIST MODERATORS
+
+   Responses
+      215    Moderators list follows (multi-line)
+
+2.4.2.  Description
+
+   See Section 7.6.1 of [RFC3977] for general requirements of the LIST
+   command.
+
+   The "moderators list" is maintained by some NNTP servers to make
+   clients aware of how the news server will generate a submission
+   e-mail address when an article is locally posted to a moderated
+   newsgroup.
+
+   The information is returned as a multi-line data block following the
+   215 response code.  Each line of this list MUST consist of two fields
+   separated from each other by a colon (":" or %x3A).  The first field
+   is a wildmat (which may be a simple newsgroup name), and the second
+
+
+
+Elie                         Standards Track                   [Page 10]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   field is the submission address template for newsgroups matching that
+   wildmat.  There are no leading or trailing whitespaces in a line.
+   The submission template MAY contain colons (":").
+
+   The submission template is essentially an e-mail address (see the
+   definition of "addr-spec" in Section 3.4.1 of [RFC5322]), except with
+   certain modifications.  The case-sensitive string "%s" (%x25.73) MUST
+   occur either zero or one time in the template.  If there is to be a
+   literal "%" in the submission address, it MUST be written as "%%" in
+   the template, even if not followed by an "s".  The character "%" MUST
+   NOT occur in the submission template, except as part of "%s" or "%%".
+
+   The order of lines in the moderators list is significant: the first
+   matching line is used.  Consequently, specific patterns should be
+   listed before general patterns.  Every moderated newsgroup name
+   SHOULD be matched by at least one line in the list; often this is
+   achieved by having a default pattern at the bottom, but other
+   approaches are acceptable, and news server software MAY leave this up
+   to the server administrator rather than enforcing it
+   programmatically.
+
+   When an article without an Approved header field is locally posted to
+   a moderated newsgroup, the server generates a submission address from
+   the corresponding submission template (that is, the second field of
+   the first matching line in the moderators list) by replacing the
+   "%s", if present, with the name of the matching newsgroup after each
+   period ("." or %x2E) in the name has been changed to a dash ("-" or
+   %x2D).  In addition, any "%%" is changed back to "%".  The server
+   then forwards the submitted article to the moderator at the resulting
+   submission address (see Section 3.5.1 of [RFC5537]).
+
+      NOTE: The creation and maintenance of submission addresses is
+      outside the scope of this specification.
+
+   The moderators list is not newsgroup-based, and an argument MUST NOT
+   be specified.  Otherwise, a 501 response code MUST be returned.
+
+   The moderators list MAY be empty.  If the server does not maintain
+   the information, a 503 response code MUST be returned, although these
+   situations should not occur if the news server is an injecting agent
+   that carries moderated newsgroups.
+
+
+
+
+
+
+
+
+
+
+Elie                         Standards Track                   [Page 11]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+2.4.3.  Example
+
+   Example of output:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] POST
+      [S] LIST ACTIVE MODERATORS NEWSGROUPS
+      [S] .
+      [C] LIST MODERATORS
+      [S] 215 List of submission address templates follows
+      [S] foo.bar:announce@example.com
+      [S] local.*:%s@localhost
+      [S] *:%s@moderators.example.com
+      [S] .
+
+   The following table describes a few examples associating a moderated
+   newsgroup and its submission address on a news server whose
+   moderators list is the one in the previous example:
+
+   +-----------------------------+-------------------------------------+
+   | Name of the moderated       | Submission address                  |
+   | newsgroup                   |                                     |
+   +-----------------------------+-------------------------------------+
+   | foo.bar                     | announce@example.com                |
+   | local.test                  | local-test@localhost                |
+   | alt.dev.null                | alt-dev-null@moderators.example.com |
+   | alt.test-me                 | alt-test-me@moderators.example.com  |
+   +-----------------------------+-------------------------------------+
+
+      NOTE: When "%s" is used, periods are changed to dashes, and dashes
+      are left alone.  This implies that two moderated newsgroups whose
+      names differ only by changing a period to a dash would have the
+      same submission address.  Therefore, if a server carries such
+      moderated newsgroup pairs but posts should go to different
+      submission addresses, a "%s" pattern template cannot be used for
+      the moderation submission addresses for those groups, and explicit
+      entries without a pattern will be required.
+
+      Similarly, it is not recommended to use a "%s" pattern rule for
+      the moderation submission template for two moderated newsgroups
+      whose names differ only by the case of their characters, because
+      e-mail systems frequently treat the left-hand side of e-mail
+      addresses as case-sensitive.  See also Section 3.1.4 of [RFC5536]
+      and Section 7.2 of [USEAGE] for the syntax of a newsgroup name.
+
+
+
+
+Elie                         Standards Track                   [Page 12]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+2.5.  LIST MOTD
+
+2.5.1.  Usage
+
+   Syntax
+      LIST MOTD
+
+   Responses
+      215    Information follows (multi-line)
+
+2.5.2.  Description
+
+   See Section 7.6.1 of [RFC3977] for general requirements of the LIST
+   command.
+
+   The "motd" contains a "message of the day" relevant to the news
+   server.  It is intended to provide notification and communication
+   between the news administrator and the news user.  For instance,
+   notification of upcoming downtime or information about new facilities
+   available on the news server can be communicated via the LIST MOTD
+   command.
+
+   The information is returned as a multi-line data block following the
+   215 response code.  This text is not guaranteed to be in any
+   particular format although, like all multi-line data blocks, it is
+   "dot-stuffed".
+
+   The server need not return the same information if this command is
+   used more than once in a session.  It MAY indeed send a different
+   message of the day depending on the state of the session.  For
+   instance, on a mode-switching news server, the information can be
+   different between its transit mode and its reader mode, or between an
+   authenticated session and an unauthenticated session.
+
+   The information MUST be in UTF-8 [RFC3629].
+
+   The motd is not newsgroup-based, and an argument MUST NOT be
+   specified.  Otherwise, a 501 response code MUST be returned.
+
+   The motd MAY be empty.  If the server does not maintain the
+   information, a 503 response code MUST be returned.
+
+   It is up to the client to decide when and how to display this message
+   to the user.  No timestamp or date of last modification is provided
+   programmatically, although the news administrator may include one in
+   the text of the motd.  The client MAY cache a local copy or
+   fingerprint of the motd so that it can display the message to the
+   user only upon modification.  If the client caches the information,
+
+
+
+Elie                         Standards Track                   [Page 13]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   it MAY take into account only the motd obtained after reaching the
+   intended state of the session.  Nonetheless, in case a privacy
+   extension is used, the client MUST NOT cache any motd obtained before
+   that extension took effect.
+
+      NOTE: Though the client MAY cache the results of this command, it
+      MUST NOT rely on the correctness of any cached results, whether
+      from earlier in the session or from a previous session.  If the
+      motd is cached, the client SHOULD provide a way to force the
+      cached information to be refreshed.
+
+2.5.3.  Example
+
+   Example of output:
+
+    [C] CAPABILITIES
+    [S] 101 Capability list:
+    [S] VERSION 2
+    [S] READER
+    [S] LIST ACTIVE MOTD NEWSGROUPS
+    [S] .
+    [C] LIST MOTD
+    [S] 215 Message of the day follows
+    [S] Attention all users,
+    [S]
+    [S] This server will be down for scheduled upgrades on February 1st.
+    [S] It should be back up by 8:00 a.m. February 2nd.
+    [S] Any questions should be e-mailed to <newsmaster@example.com>.
+    [S]
+    [S] Apologies for the disturbance.
+    [S] .
+
+2.6.  LIST SUBSCRIPTIONS
+
+2.6.1.  Usage
+
+   Syntax
+      LIST SUBSCRIPTIONS [wildmat]
+
+   Responses
+      215    Subscriptions list follows (multi-line)
+
+   Parameters
+      wildmat    Groups of interest
+
+
+
+
+
+
+
+Elie                         Standards Track                   [Page 14]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+2.6.2.  Description
+
+   See Section 7.6.1 of [RFC3977] for general requirements of the LIST
+   command.
+
+   The "subscriptions list" is maintained by some NNTP servers to
+   provide the client with a list of recommended newsgroups.
+
+   The information is returned as a multi-line data block following the
+   215 response code.  Each line of this list MUST consist of a
+   newsgroup name.  There are no leading or trailing whitespaces in a
+   line.
+
+   The order of newsgroups in the subscriptions list is significant:
+   they are listed by order of importance, the first newsgroup being the
+   most important to subscribe to.
+
+   The same newsgroup name SHOULD NOT appear twice in the output of this
+   command.  The subscriptions list SHOULD contain only newsgroups the
+   news server carries.
+
+   The subscriptions list is newsgroup-based, and a wildmat MAY be
+   specified, in which case the response is limited to only the groups,
+   if any, whose names match the wildmat.  Note that the wildmat
+   argument is a new feature in this specification, and servers that do
+   not support CAPABILITIES or do not advertise the SUBSCRIPTIONS
+   keyword in the LIST capability (and therefore do not conform to this
+   specification) are unlikely to support it.
+
+   The subscriptions list MAY be empty.  If the server does not maintain
+   the information, a 503 response code MUST be returned.
+
+   The client MAY use this information the first time it connects to the
+   news server so as to initialize the list of default subscribed
+   newsgroups.  This list should therefore contain groups intended for
+   new users on the news server or Usenet in general (for instance,
+   newsgroups dedicated to testing, support, announcement, or FAQs).
+   The client MAY present the groups in the order of appearance in the
+   list to the user.  When the subscriptions list is maintained and
+   non-empty, the news client SHOULD use it, instead of a hard-coded
+   default list, if any.
+
+
+
+
+
+
+
+
+
+
+Elie                         Standards Track                   [Page 15]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+2.6.3.  Examples
+
+   Example of output with no argument:
+
+      [C] CAPABILITIES
+      [S] 101 Capability list:
+      [S] VERSION 2
+      [S] READER
+      [S] LIST ACTIVE NEWSGROUPS SUBSCRIPTIONS
+      [S] .
+      [C] LIST SUBSCRIPTIONS
+      [S] 215 List of recommended newsgroups follows
+      [S] local.welcome
+      [S] local.test
+      [S] news.newusers.questions
+      [S] news.announce.newusers
+      [S] .
+
+   Example of output with a wildmat:
+
+      [C] LIST SUBSCRIPTIONS local.*
+      [S] 215 List of recommended newsgroups follows
+      [S] local.welcome
+      [S] local.test
+      [S] .
+
+3.  Additions to LIST ACTIVE
+
+   This document specifies three new status field values that can be
+   used in the answers to LIST ACTIVE: "x", "j", and "=" followed by the
+   name of a newsgroup.
+
+3.1.  New Status Field Values
+
+   The LIST ACTIVE command is defined in Section 7.6.3 of [RFC3977].
+   The fourth field of each line of this list indicates the current
+   status of the newsgroup whose name is specified in the first field.
+   Three status field values are defined in [RFC3977]:
+
+   "y"  Posting is permitted.
+
+   "n"  Posting is not permitted.
+
+   "m"  Postings will be forwarded to the newsgroup moderator.
+
+
+
+
+
+
+
+Elie                         Standards Track                   [Page 16]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   This document defines three other case-sensitive status field values
+   that can also be used:
+
+   "x"  Postings and articles from peers are not permitted.
+
+   "j"  Only articles from peers are permitted; no articles are locally
+      filed.
+
+   "=other.group"  Only articles from peers are permitted, and are filed
+      under the newsgroup named "other.group".
+
+   The server SHOULD use these values when these meanings are required
+   and MUST NOT use them with any other meaning.
+
+   A newsgroup with status "x" is a newsgroup with status "n", except
+   that articles from peers are not accepted.  A newsgroup with status
+   "x" is considered as closed: no new articles will arrive in such a
+   group.  On the contrary, articles from peers will arrive in a
+   newsgroup with status "n".  Local postings are not allowed in a
+   newsgroup with either of these two status field values.
+
+   A newsgroup with status "j" is a newsgroup with status "y", except
+   that (1) local postings are not accepted, (2) articles received from
+   a peer that are crossposted to one or more valid groups are filed
+   only into those valid groups, and (3) articles received from a peer
+   that are not crossposted to any valid groups are not filed into any
+   newsgroup, but are still propagated to other peers, if appropriate.
+
+      NOTE: Instead of not filing at all an article posted to a
+      newsgroup with status "j", a news server MAY file it under a
+      catch-all group if no valid group is applicable.  When a news
+      server uses a catch-all group to file the articles posted to
+      newsgroups with status "j", this catch-all group SHOULD be named
+      "junk".  (The first letter of the "junk" newsgroup explains why
+      this status has been called "j".)
+
+      Consequently, when a news server carries the "junk" newsgroup and
+      uses it for the purpose of the "j" status, the "junk" newsgroup
+      contains all postings not filed under another newsgroup,
+      regardless of the status of the "junk" newsgroup.  (However, an
+      article posted explicitly to "junk" is treated according to the
+      status of the "junk" newsgroup.)
+
+      The "junk" newsgroup may be available to news readers and is often
+      used by a news server as a way to locally store an article that
+      will be transmitted to peers (which may carry some of the
+      newsgroups the article was posted to even if the local server does
+      not).  In addition, instead of rejecting an article that contains
+
+
+
+Elie                         Standards Track                   [Page 17]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+      an invalid Newsgroups header field or that is posted to newsgroups
+      it does not carry, a news server may accept such an article and
+      file it under the catch-all newsgroup.
+
+      Depending on the configuration of the news server, mentioning a
+      newsgroup with status "j" is different than simply not listing the
+      group, since articles arriving for unknown newsgroups may be
+      rejected.
+
+   When the status field value begins with an equal sign ("=" or %x3D),
+   a newsgroup name on the news server MUST immediately follow the sign.
+   If the status of "foo.bar" is "=other.group", it means that "foo.bar"
+   is an alias for "other.group".  These two newsgroups are distinct;
+   they do not share their articles or their article numbers.  Local
+   postings to "foo.bar" are not allowed, but articles from peers are
+   accepted for "foo.bar" and filed into "other.group", regardless of
+   the status of "other.group".  The contents of their Newsgroups header
+   fields MUST NOT be altered.
+
+   Alias groups are typically used during a transition between two
+   newsgroups, including but not limited to a renaming of a group, or a
+   correction of a misspelled group name.
+
+   The status of the newsgroup an alias points to MUST NOT be taken into
+   account when an article arrives in an alias newsgroup.  In
+   particular, it means that unapproved articles arriving from peers in
+   an alias pointing to a moderated newsgroup are accepted and filed
+   into this moderated newsgroup.  Therefore, an alias SHOULD NOT point
+   to a moderated newsgroup, since it allows bypassing of the
+   moderation.
+
+   An alias SHOULD NOT point to itself or another alias group.  The
+   newsgroup an alias points to SHOULD exist on the news server, and be
+   visible to any client that can see the original group.  However, when
+   a client issues a LIST ACTIVE command with a wildmat including the
+   original group, the newsgroup it points to is not listed in the
+   response (unless of course the second newsgroup also matches the
+   wildmat).
+
+      NOTE: If a server files newsgroups with status "j" into "junk", a
+      newsgroup with status "j" and a newsgroup with status "=junk" are
+      different.  An article fed by a peer, and crossposted to a group
+      with status "j", will result in the article being filed only in
+      "junk" if there are no other groups with which to file it, or
+      otherwise only in other valid newsgroups it is crossposted to.  On
+      the other hand, an article fed by a peer, and crossposted to a
+      group with status "=junk", will result in the article being filed
+      in "junk" and in other valid newsgroups it is crossposted to.
+
+
+
+Elie                         Standards Track                   [Page 18]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   The following table summarizes what usually happens to an article
+   posted to only the newsgroup "foo.bar", depending on its status field
+   value on the news server:
+
+   +---------------+------------+-----------+------------+-------------+
+   | Status field  | Accepted   | Accepted  | Moderation | Destination |
+   | value of      | if local   | from      | needed?    | if accepted |
+   | "foo.bar"     | posting?   | peers?    |            |             |
+   +---------------+------------+-----------+------------+-------------+
+   | y             | Yes        | Yes       | No         | foo.bar     |
+   | n             | No         | Yes       | No         | foo.bar     |
+   | m             | Yes        | Yes       | Yes        | foo.bar     |
+   | x             | No         | No        | No         |             |
+   | j             | No         | Yes       | No         | junk (if    |
+   |               |            |           |            | filed)      |
+   | =other.group  | No         | Yes       | No         | other.group |
+   +---------------+------------+-----------+------------+-------------+
+
+   The following table summarizes what usually happens to an article
+   crossposted to the newsgroup "foo.bar" and a valid newsgroup
+   "misc.test" (whose status field is "y") known by the news server,
+   depending on the status field value of "foo.bar" on the news server:
+
+   +---------------+-----------+-----------+------------+--------------+
+   | Status field  | Accepted  | Accepted  | Moderation | Destination  |
+   | value of      | if local  | from      | needed?    | if accepted  |
+   | "foo.bar"     | posting?  | peers?    |            |              |
+   +---------------+-----------+-----------+------------+--------------+
+   | y             | Yes       | Yes       | No         | foo.bar,     |
+   |               |           |           |            | misc.test    |
+   | n             | No        | Yes       | No         | foo.bar,     |
+   |               |           |           |            | misc.test    |
+   | m             | Yes       | Yes       | Yes        | foo.bar,     |
+   |               |           |           |            | misc.test    |
+   | x             | No        | Yes       | No         | misc.test    |
+   | j             | No        | Yes       | No         | misc.test    |
+   | =other.group  | No        | Yes       | No         | other.group, |
+   |               |           |           |            | misc.test    |
+   +---------------+-----------+-----------+------------+--------------+
+
+      NOTE: The status of a newsgroup only indicates how articles
+      arriving for that newsgroup are normally processed; news servers
+      MAY provide clients with special privileges to allow or disallow
+      some rights in these newsgroups.  This specification defines
+      neither these rights nor whether or not articles posted to these
+      groups should be propagated to other peers.
+
+
+
+
+
+Elie                         Standards Track                   [Page 19]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+3.2.  Examples
+
+   Example of an article posted to an alias group by a peer:
+
+      [C] LIST ACTIVE
+      [S] 215 List of newsgroups follows
+      [S] foo.bar 21 12 y
+      [S] misc.test 3002322 3000234 =foo.bar
+      [S] .
+      [C] IHAVE <for.misc.test@example.com>
+      [S] 335 Send it; end with <CR-LF>.<CR-LF>
+      [C] Path: demo!.POSTED.somewhere!not-for-mail
+      [C] From: "Demo User" <nobody@example.com>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] Date: 18 Oct 2008 16:02:45 +0200
+      [C] Organization: An example, Paris, FR.
+      [C] Message-ID: <for.misc.test@example.com>
+      [C] MIME-Version: 1.0
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [S] 235 Article transferred OK
+      [C] LIST ACTIVE
+      [S] 215 List of newsgroups follows
+      [S] foo.bar 22 12 y
+      [S] misc.test 3002322 3000234 =foo.bar
+      [S] .
+      [C] HDR Xref <for.misc.test@example.com>
+      [S] 225 Header information follows
+      [S] 0 news.example.com foo.bar:22
+      [S] .
+      [C] HDR Newsgroups <for.misc.test@example.com>
+      [S] 225 Header information follows
+      [S] 0 misc.test
+      [S] .
+
+   The Newsgroups header field of this article is kept untouched.  This
+   article is filed under "foo.bar" even though it has originally been
+   posted to the newsgroup "misc.test".  Yet, it still propagates to
+   peers that have been configured to receive articles posted to
+   "misc.text".
+
+
+
+
+
+
+
+
+
+Elie                         Standards Track                   [Page 20]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   Example of an article locally posted to an alias group:
+
+      [C] LIST ACTIVE
+      [S] 215 List of newsgroups follows
+      [S] foo.bar 22 12 y
+      [S] misc.test 3002322 3000234 =foo.bar
+      [S] .
+      [C] POST
+      [S] 340 Input article; end with <CR-LF>.<CR-LF>
+      [C] From: "Demo User" <nobody@example.com>
+      [C] Newsgroups: misc.test
+      [C] Subject: I am just a test article
+      [C] MIME-Version: 1.0
+      [C]
+      [C] This is just a test article.
+      [C] .
+      [S] 441 Newsgroup "misc.test" has been renamed to "foo.bar"
+
+   The article is rejected, with a detailed error.
+
+4.  Augmented BNF Syntax for These Additions to the LIST Command
+
+   This section describes the formal syntax of the new LIST variants
+   defined in this document using [RFC5234].  It extends the syntax in
+   Section 9 of [RFC3977], and non-terminals not defined in this
+   document are defined there.  The [RFC3977] ABNF should be imported
+   first, before attempting to validate these rules.
+
+4.1.  Commands
+
+   This syntax extends the non-terminal <list-arguments>, which
+   represents the variants of the LIST command.
+
+     ; counts
+     list-arguments =/ "COUNTS" [WS wildmat]
+
+     ; distributions, moderators, motd
+     list-arguments =/ "DISTRIBUTIONS" / "MODERATORS" / "MOTD"
+
+     ; subscriptions
+     list-arguments =/ "SUBSCRIPTIONS" [WS wildmat]
+
+4.2.  Responses
+
+   This syntax extends the non-terminals <newsgroup-status> and
+   <list-content>, which represent the status field value returned by
+   the LIST ACTIVE command and the response contents for the LIST
+   command, respectively.
+
+
+
+Elie                         Standards Track                   [Page 21]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+     ; active
+     newsgroup-status =/ newsgroup-alias /
+           %x78 / %x6a  ; case-sensitive "x" and "j"
+     newsgroup-alias =  "=" newsgroup-name
+
+     ; counts
+     list-content =/ list-counts-content
+     list-counts-content =
+           *(newsgroup-name 3(SPA article-number)
+           SPA newsgroup-status CRLF)
+
+     ; distributions
+     list-content =/ list-distributions-content
+     list-distributions-content =
+           *(distribution WS distribution-description CRLF)
+     distribution-description = U-TEXT
+
+     ; moderators
+     list-content =/ list-moderators-content
+     list-moderators-content =
+           *(wildmat ":" moderators-address CRLF)
+     moderators-address = S-TEXT
+
+     ; motd
+     list-content =/ list-motd-content
+     list-motd-content = *(*U-CHAR CRLF)
+
+     ; subscriptions
+     list-content =/ list-subscriptions-content
+     list-subscriptions-content = *(newsgroup-name CRLF)
+
+5.  Internationalization Considerations
+
+   No new internationalization considerations are introduced by this
+   extension, beyond those already described in the core specification
+   [RFC3977].
+
+   In particular, newsgroup names SHOULD be restricted to US-ASCII
+   [ASCII] until a successor to [RFC5536] standardizes another approach.
+
+   Distribution descriptions and the message of the day MUST be in UTF-8
+   [RFC3629].
+
+
+
+
+
+
+
+
+
+Elie                         Standards Track                   [Page 22]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+6.  Security Considerations
+
+   No new security considerations are introduced by this extension,
+   beyond those already described in the core specification [RFC3977]
+   and the Netnews Architecture and Protocols specification [RFC5537]
+   (especially distribution leakage and e-mail Denial of Service during
+   the moderation process).
+
+7.  IANA Considerations
+
+   This section gives a formal definition of this extension as required
+   by Section 3.3.3 of [RFC3977] for the IANA registry.  It extends the
+   LIST capability label defined in Section 7.6 of [RFC3977].
+
+   o  This extension provides additional keywords to the pre-existing
+      LIST capability defined in Section 7.6 of [RFC3977].  New status
+      field values are also added to the ACTIVE variant of the LIST
+      command.
+
+   o  The capability label that this extension extends is "LIST".
+
+   o  This extension adds five optional arguments to the "LIST"
+      capability label: "COUNTS", "DISTRIBUTIONS", "MODERATORS", "MOTD",
+      and "SUBSCRIPTIONS", indicating which new variants of the LIST
+      command are supported.  Consequently, this extension associates
+      these new arguments with the pre-existing "LIST" NNTP command.
+
+   o  This extension defines five new commands, LIST COUNTS, LIST
+      DISTRIBUTIONS, LIST MODERATORS, LIST MOTD, and LIST SUBSCRIPTIONS,
+      whose behavior, arguments, and responses are defined in
+      Sections 2.2, 2.3, 2.4, 2.5, and 2.6, respectively.
+
+   o  This extension does not associate any new responses with pre-
+      existing NNTP commands.
+
+   o  This extension does not affect the maximum length of commands or
+      initial response lines.
+
+   o  This extension does not alter pipelining.  The LIST COUNTS, LIST
+      DISTRIBUTIONS, LIST MODERATORS, LIST MOTD, and LIST SUBSCRIPTIONS
+      commands can be pipelined.
+
+   o  Use of this extension does not alter the capabilities list.
+
+   o  This extension does not cause any pre-existing command to produce
+      a 401, 480, or 483 response.
+
+
+
+
+
+Elie                         Standards Track                   [Page 23]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   o  This extension is unaffected by any use of the MODE READER
+      command.
+
+   o  This extension does not affect the overall behavior of a server or
+      client other than via the new commands.
+
+   o  Published Specification: This document.
+
+   o  Contact for Further Information: Author of this document.
+
+   o  Change Controller: IESG <iesg@ietf.org>.
+
+8.  Acknowledgements
+
+   The author gratefully acknowledges the comments and additional
+   information provided by Russ Allbery, Urs Janssen, Antti-Juhani
+   Kaijanaho, Alexey Melnikov, Peter Saint-Andre, Dieter Stussy, and
+   Sean Turner on this document.
+
+   The author would particularly like to thank Jeffrey M. Vinocur for
+   having reread, improved, and patiently fixed the English wording and
+   the quality of this document.
+
+   Special thanks are due to:
+
+      Stan Barber, whose text in [RFC2980] served as the initial basis
+      for the DISTRIBUTIONS and SUBSCRIPTIONS variants of the LIST
+      command.
+
+      Brian Hernacki, whose text in [NNTP_LIST] served as the initial
+      basis for the MOTD and also the SUBSCRIPTIONS variants of the LIST
+      command.
+
+      The authors of the documentation of a few sample files of the
+      InterNetNews news server ("active", "distributions", "moderators",
+      "motd.news", and "subscriptions"): Russ Allbery, Bettina Fink,
+      Rich Salz, and a few other people to whom I am also grateful.
+
+9.  References
+
+9.1.  Normative References
+
+   [RFC2119]    Bradner, S., "Key words for use in RFCs to Indicate
+                Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3629]    Yergeau, F., "UTF-8, a transformation format of ISO
+                10646", STD 63, RFC 3629, November 2003.
+
+
+
+
+Elie                         Standards Track                   [Page 24]
+
+RFC 6048             NNTP Additions to LIST Command        November 2010
+
+
+   [RFC3977]    Feather, C., "Network News Transfer Protocol (NNTP)",
+                RFC 3977, October 2006.
+
+   [RFC5234]    Crocker, D. and P. Overell, "Augmented BNF for Syntax
+                Specifications: ABNF", STD 68, RFC 5234, January 2008.
+
+   [RFC5322]    Resnick, P., Ed., "Internet Message Format", RFC 5322,
+                October 2008.
+
+9.2.  Informative References
+
+   [ASCII]      American National Standards Institute, "Coded Character
+                Sets - 7-Bit American Standard Code for Information
+                Interchange (7-Bit ASCII), ANSI X3.4", 1986.
+
+   [NNTP_LIST]  Hernacki, B., "NNTP LIST Additions", Work in Progress,
+                July 1997.
+
+   [RFC2980]    Barber, S., "Common NNTP Extensions", RFC 2980,
+                October 2000.
+
+   [RFC5536]    Murchison, K., Lindsey, C., and D. Kohn, "Netnews
+                Article Format", RFC 5536, November 2009.
+
+   [RFC5537]    Allbery, R. and C. Lindsey, "Netnews Architecture and
+                Protocols", RFC 5537, November 2009.
+
+   [USEAGE]     Lindsey, C., "Usenet Best Practice", Work in Progress,
+                March 2005.
+
+Author's Address
+
+   Julien Elie
+   13 rue Marx Dormoy
+   Noisy-le-Grand  93160
+   France
+
+   EMail: julien@trigofacile.com
+   URI:   http://www.trigofacile.com/
+
+
+
+
+
+
+
+
+
+
+
+
+Elie                         Standards Track                   [Page 25]
+


### PR DESCRIPTION
### CHANGELOG
- Updated doc with **RFC 3977** (_which obsoletes RFC 977_) and NNTP extensions.
- Added partial support for `NEWGROUPS` command (missing: `[<distributions>]` optional argument support) **with** `[GMT]` **optional argument support**.
- Added complete support for `NEWNEWS` command **with** `[GMT]` **optional argument support**.
